### PR TITLE
Technical Enhancement - Incremental Static Page Regeneration

### DIFF
--- a/components/SignUp/SignupForm/SignupForm.tsx
+++ b/components/SignUp/SignupForm/SignupForm.tsx
@@ -3,7 +3,7 @@ import { useUserSession } from "components/context/UserSessionContext";
 import { Navigation } from "components/enum/navigation";
 import { ActionSuccessPanel } from "components/shared/ActionSuccessPanel";
 import { FormContainer } from "components/shared/FormContainer";
-import { GENERIC_ERROR_MESSAGE } from "../../../consts";
+import { GENERIC_ERROR_MESSAGE } from "consts";
 import { useSignup } from "../useSignup";
 
 interface Props {

--- a/components/SignUp/SignupForm/SignupForm.tsx
+++ b/components/SignUp/SignupForm/SignupForm.tsx
@@ -3,7 +3,7 @@ import { useUserSession } from "components/context/UserSessionContext";
 import { Navigation } from "components/enum/navigation";
 import { ActionSuccessPanel } from "components/shared/ActionSuccessPanel";
 import { FormContainer } from "components/shared/FormContainer";
-import { GENERIC_ERROR_MESSAGE } from "../../../constants";
+import { GENERIC_ERROR_MESSAGE } from "../../../consts";
 import { useSignup } from "../useSignup";
 
 interface Props {

--- a/components/Submit/Submit.tsx
+++ b/components/Submit/Submit.tsx
@@ -1,6 +1,6 @@
 import { useSupabase } from "components/hooks/useSupabaseClient";
 import { FormContainer } from "components/shared/FormContainer";
-import { GENERIC_ERROR_MESSAGE } from "../../constants";
+import { GENERIC_ERROR_MESSAGE } from "../../consts";
 import { getIsSuccess } from "utils";
 import { ActionSuccessPanel } from "components/shared/ActionSuccessPanel";
 import { useUserSession } from "components/context/UserSessionContext";

--- a/components/Submit/Submit.tsx
+++ b/components/Submit/Submit.tsx
@@ -1,6 +1,6 @@
 import { useSupabase } from "components/hooks/useSupabaseClient";
 import { FormContainer } from "components/shared/FormContainer";
-import { GENERIC_ERROR_MESSAGE } from "../../consts";
+import { GENERIC_ERROR_MESSAGE } from "consts";
 import { getIsSuccess } from "utils";
 import { ActionSuccessPanel } from "components/shared/ActionSuccessPanel";
 import { useUserSession } from "components/context/UserSessionContext";

--- a/components/Voting/VotingForm/VotingForm.tsx
+++ b/components/Voting/VotingForm/VotingForm.tsx
@@ -1,7 +1,7 @@
 import { useUserSession } from "components/context/UserSessionContext";
 import { ActionSuccessPanel } from "components/shared/ActionSuccessPanel";
 import { FormContainer } from "components/shared/FormContainer";
-import { GENERIC_ERROR_MESSAGE } from "../../../consts";
+import { GENERIC_ERROR_MESSAGE } from "consts";
 import { useVoting } from "../useVoting";
 
 interface Props {

--- a/components/Voting/VotingForm/VotingForm.tsx
+++ b/components/Voting/VotingForm/VotingForm.tsx
@@ -1,7 +1,7 @@
 import { useUserSession } from "components/context/UserSessionContext";
 import { ActionSuccessPanel } from "components/shared/ActionSuccessPanel";
 import { FormContainer } from "components/shared/FormContainer";
-import { GENERIC_ERROR_MESSAGE } from "../../../constants";
+import { GENERIC_ERROR_MESSAGE } from "../../../consts";
 import { useVoting } from "../useVoting";
 
 interface Props {

--- a/consts.ts
+++ b/consts.ts
@@ -1,2 +1,4 @@
 export const GENERIC_ERROR_MESSAGE =
   "An error has occurred. Please try again and/or hit Nate up.";
+
+export const STATIC_REGEN_INTERVAL_SECONDS = 3600;

--- a/pages/blog/[slug].tsx
+++ b/pages/blog/[slug].tsx
@@ -1,5 +1,6 @@
 import { Post } from "components/Blog/Post/Post";
 import { PageContainer } from "components/shared/PageContainer";
+import { STATIC_REGEN_INTERVAL_SECONDS } from "consts";
 import { getAllPosts } from "serverFunctions/getAllPosts";
 import { BlogPost } from "types/BlogPost";
 
@@ -22,6 +23,7 @@ export async function getStaticProps({
   return {
     // Passed to the page component as props
     props: { post },
+    revalidate: STATIC_REGEN_INTERVAL_SECONDS,
   };
 }
 

--- a/pages/blog/index.tsx
+++ b/pages/blog/index.tsx
@@ -4,6 +4,7 @@ import { GetServerSidePropsContext } from "next";
 import { BlogHome } from "components/Blog";
 import { getAllPosts } from "serverFunctions/getAllPosts";
 import { BlogPost } from "types/BlogPost";
+import { STATIC_REGEN_INTERVAL_SECONDS } from "consts";
 
 function BlogPage({ posts }: { posts: BlogPost[] }) {
   return (
@@ -19,6 +20,7 @@ export async function getStaticProps(ctx: GetServerSidePropsContext) {
     props: {
       posts,
     },
+    revalidate: STATIC_REGEN_INTERVAL_SECONDS,
   };
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,6 +5,7 @@ import { Homepage, Props } from "../components/Homepage";
 
 import { getSupabaseClient } from "../utils/getSupabaseClient";
 import { format } from "date-fns";
+import { STATIC_REGEN_INTERVAL_SECONDS } from "consts";
 
 const Home = (props: Props) => {
   return <Homepage {...props} />;
@@ -71,6 +72,7 @@ export const getStaticProps: GetStaticProps = async () => {
         roundId,
       },
     },
+    revalidate: STATIC_REGEN_INTERVAL_SECONDS,
   };
 };
 

--- a/pages/profile/[username].tsx
+++ b/pages/profile/[username].tsx
@@ -3,6 +3,7 @@ import { TableContainer } from "@chakra-ui/table";
 import { sharedHeaders } from "components/Profile/ProfileDisplay";
 import { DataTable } from "components/shared/DataTable";
 import { PageContainer } from "components/shared/PageContainer";
+import { STATIC_REGEN_INTERVAL_SECONDS } from "consts";
 import { Views } from "queries";
 import { getSupabaseClient } from "utils/getSupabaseClient";
 
@@ -37,6 +38,7 @@ export async function getStaticProps({
       username,
       data,
     },
+    revalidate: STATIC_REGEN_INTERVAL_SECONDS,
   };
 }
 

--- a/pages/reporting.tsx
+++ b/pages/reporting.tsx
@@ -1,3 +1,4 @@
+import { STATIC_REGEN_INTERVAL_SECONDS } from "consts";
 import { GetStaticProps, InferGetStaticPropsType } from "next";
 import { Views } from "queries";
 import React from "react";
@@ -27,6 +28,7 @@ export const getStaticProps: GetStaticProps = async () => {
         isWinningSong: !!((song.round_metadata as []) || []).length,
       })),
     },
+    revalidate: STATIC_REGEN_INTERVAL_SECONDS,
   };
 };
 

--- a/pages/round/[id].tsx
+++ b/pages/round/[id].tsx
@@ -7,6 +7,7 @@ import {
   VoteResults,
 } from "components/RoundSummary";
 import { PageContainer } from "components/shared/PageContainer";
+import { STATIC_REGEN_INTERVAL_SECONDS } from "consts";
 import { Tables, Views } from "queries";
 import { Phase, PhaseMgmtService } from "services/PhaseMgmtService";
 import { getSupabaseClient } from "utils/getSupabaseClient";
@@ -66,6 +67,7 @@ export async function getStaticProps({
       voteBreakdown,
       navigation,
     },
+    revalidate: STATIC_REGEN_INTERVAL_SECONDS,
   };
 }
 

--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -2,6 +2,7 @@ import { GetStaticProps, InferGetStaticPropsType } from "next";
 import React from "react";
 import { Submit } from "components/Submit";
 import { PhaseMgmtService } from "services/PhaseMgmtService";
+import { STATIC_REGEN_INTERVAL_SECONDS } from "consts";
 
 const SubmitPage = ({
   roundId,
@@ -40,6 +41,7 @@ export const getStaticProps: GetStaticProps = async () => {
       song,
       phase,
     },
+    revalidate: STATIC_REGEN_INTERVAL_SECONDS,
   };
 };
 

--- a/pages/voting.tsx
+++ b/pages/voting.tsx
@@ -6,6 +6,7 @@ import queries from "queries";
 import { PhaseMgmtService } from "services/PhaseMgmtService";
 import { SignInGate } from "components/shared/SignInGate";
 import seedrandom from "seedrandom";
+import { STATIC_REGEN_INTERVAL_SECONDS } from "consts";
 
 const VotingPage = ({
   voteOptions,
@@ -49,6 +50,7 @@ export const getStaticProps: GetStaticProps = async () => {
       isVotingOpen,
       coveringStartString,
     },
+    revalidate: STATIC_REGEN_INTERVAL_SECONDS,
   };
 };
 


### PR DESCRIPTION
[Associated RFC](https://github.com/nspilman/rfcs/blob/main/EPTSS%20-%20Incremental%20Static%20regeneration.md)

Static sites are both faster for end users, but also more straight forward to implement (imho). The downside of static sites, though, is that they generate at website build time, and therefore data might get stale. Incremental Static Regeneration gives us the opportunity to keep the data considerably more fresh for end users while still reaping the static site benefits.

My plan is to add a revalidate: 3600 to trigger page specific rebuilds at most once an hour. I will write future RFCs we deem it makes sense to implement On Demand Revalidation.
