### PR TITLE
Remove Round ID Fallbacks and Legacy Code

### DIFF
--- a/app/index/Homepage/RoundsDisplay/ClientRoundsDisplay.tsx
+++ b/app/index/Homepage/RoundsDisplay/ClientRoundsDisplay.tsx
@@ -63,7 +63,7 @@ export const ClientRoundsDisplay = ({ rounds, currentRoundId, isVotingPhase }: P
                   animate={{ y: 0, opacity: 1 }}
                   transition={{ delay: index * 0.1 }}
                 >
-                  <Link href={`round/${round.slug || round.roundId}`}>
+                  <Link href={`round/${round.slug}`}>
                     <div className={`p-6 rounded-lg border ${isCurrent ? 'bg-[var(--color-gray-800)]/60 border-[var(--color-accent-primary)]' : 'bg-[var(--color-background-tertiary)] border-[var(--color-gray-800)] hover:border-[var(--color-gray-700)]'} transition-all duration-200`}>
                       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
                         <div>

--- a/app/round/[slug]/components/RoundNavigation.tsx
+++ b/app/round/[slug]/components/RoundNavigation.tsx
@@ -17,6 +17,7 @@ export const RoundNavigation: React.FC<NavigationProps> = ({ navigation }) => {
     <div className="flex justify-between w-full">
       {navigation.previous ? (
 <<<<<<< HEAD
+<<<<<<< HEAD
         <Link href={`/round/${navigation.previousSlug || navigation.previous}`}>
           <button className="btn-main">Previous Round</button>
         </Link>
@@ -39,6 +40,18 @@ export const RoundNavigation: React.FC<NavigationProps> = ({ navigation }) => {
         </a>
       ) : <></>}
 >>>>>>> 88de1ea (referencing rounds by slug)
+=======
+        <Link href={`/round/${navigation.previousSlug || navigation.previous}`}>
+          <button className="btn-main">Previous Round</button>
+        </Link>
+      ) : <div/>}
+      
+      {navigation.next ? (
+        <Link href={`/round/${navigation.nextSlug || navigation.next}`}>
+          <button className="btn-main">Next Round</button>
+        </Link>
+      ) : <div/>}
+>>>>>>> 0628312 (wiring it all through)
     </div>
   );
 };

--- a/app/round/[slug]/components/RoundNavigation.tsx
+++ b/app/round/[slug]/components/RoundNavigation.tsx
@@ -16,6 +16,7 @@ export const RoundNavigation: React.FC<NavigationProps> = ({ navigation }) => {
   return (
     <div className="flex justify-between w-full">
       {navigation.previous ? (
+<<<<<<< HEAD
         <Link href={`/round/${navigation.previousSlug || navigation.previous}`}>
           <button className="btn-main">Previous Round</button>
         </Link>
@@ -26,6 +27,18 @@ export const RoundNavigation: React.FC<NavigationProps> = ({ navigation }) => {
           <button className="btn-main">Next Round</button>
         </Link>
       ) : <div/>}
+=======
+        <a href={`/round/${navigation.previousSlug || navigation.previous}`}>
+          <button className="btn-main">Round {navigation.previous}</button>
+        </a>
+      ) : <div/>}
+      
+      {navigation.next ? (
+        <a href={`/round/${navigation.nextSlug || navigation.next}`}>
+          <button className="btn-main">Round {navigation.next}</button>
+        </a>
+      ) : <></>}
+>>>>>>> 88de1ea (referencing rounds by slug)
     </div>
   );
 };

--- a/app/round/[slug]/components/RoundNavigation.tsx
+++ b/app/round/[slug]/components/RoundNavigation.tsx
@@ -16,8 +16,6 @@ export const RoundNavigation: React.FC<NavigationProps> = ({ navigation }) => {
   return (
     <div className="flex justify-between w-full">
       {navigation.previous ? (
-<<<<<<< HEAD
-<<<<<<< HEAD
         <Link href={`/round/${navigation.previousSlug || navigation.previous}`}>
           <button className="btn-main">Previous Round</button>
         </Link>
@@ -28,30 +26,6 @@ export const RoundNavigation: React.FC<NavigationProps> = ({ navigation }) => {
           <button className="btn-main">Next Round</button>
         </Link>
       ) : <div/>}
-=======
-        <a href={`/round/${navigation.previousSlug || navigation.previous}`}>
-          <button className="btn-main">Round {navigation.previous}</button>
-        </a>
-      ) : <div/>}
-      
-      {navigation.next ? (
-        <a href={`/round/${navigation.nextSlug || navigation.next}`}>
-          <button className="btn-main">Round {navigation.next}</button>
-        </a>
-      ) : <></>}
->>>>>>> 88de1ea (referencing rounds by slug)
-=======
-        <Link href={`/round/${navigation.previousSlug || navigation.previous}`}>
-          <button className="btn-main">Previous Round</button>
-        </Link>
-      ) : <div/>}
-      
-      {navigation.next ? (
-        <Link href={`/round/${navigation.nextSlug || navigation.next}`}>
-          <button className="btn-main">Next Round</button>
-        </Link>
-      ) : <div/>}
->>>>>>> 0628312 (wiring it all through)
     </div>
   );
 };

--- a/app/rounds/page.tsx
+++ b/app/rounds/page.tsx
@@ -15,7 +15,7 @@ export default async function RoundsPage() {
       
       return {
         roundId: round.roundId,
-        slug: round.slug || round.roundId.toString(),
+        slug: round.slug,
         phase: "celebration",
         song: round.song,
         dateLabels: {

--- a/data-access/roundService.ts
+++ b/data-access/roundService.ts
@@ -81,10 +81,14 @@ const mapToRound = (dbRound: any): Round => {
 export interface Round {
   roundId: number;
 <<<<<<< HEAD
+<<<<<<< HEAD
   slug: string;
 =======
   slug?: string;
 >>>>>>> 88de1ea (referencing rounds by slug)
+=======
+  slug: string;
+>>>>>>> 0628312 (wiring it all through)
   signupOpens: Date;
   votingOpens: Date;
   coveringBegins: Date;

--- a/data-access/roundService.ts
+++ b/data-access/roundService.ts
@@ -80,15 +80,7 @@ const mapToRound = (dbRound: any): Round => {
 
 export interface Round {
   roundId: number;
-<<<<<<< HEAD
-<<<<<<< HEAD
   slug: string;
-=======
-  slug?: string;
->>>>>>> 88de1ea (referencing rounds by slug)
-=======
-  slug: string;
->>>>>>> 0628312 (wiring it all through)
   signupOpens: Date;
   votingOpens: Date;
   coveringBegins: Date;
@@ -291,24 +283,6 @@ export const getAllRoundSlugs = async (): Promise<AsyncResult<string[]>> => {
     return createSuccessResult(rounds.map(round => round.slug || round.id.toString()));
   } catch (error) {
     return createErrorResult(error instanceof Error ? error : new Error('Failed to get round slugs'));
-  }
-};
-
-// Keep the original function for backward compatibility
-export const getAllRoundIds = async (): Promise<AsyncResult<number[]>> => {
-  try {
-    const rounds = await db
-      .select({ id: roundMetadata.id })
-      .from(roundMetadata)
-      .orderBy(sql`${roundMetadata.id} ASC`);
-
-    if (!rounds.length) {
-      return createEmptyResult('No rounds found');
-    }
-
-    return createSuccessResult(rounds.map(round => round.id));
-  } catch (error) {
-    return createErrorResult(error instanceof Error ? error : new Error('Failed to get all round IDs'));
   }
 };
 

--- a/data-access/roundService.ts
+++ b/data-access/roundService.ts
@@ -80,7 +80,11 @@ const mapToRound = (dbRound: any): Round => {
 
 export interface Round {
   roundId: number;
+<<<<<<< HEAD
   slug: string;
+=======
+  slug?: string;
+>>>>>>> 88de1ea (referencing rounds by slug)
   signupOpens: Date;
   votingOpens: Date;
   coveringBegins: Date;

--- a/providers/votesProvider/votesProvider.ts
+++ b/providers/votesProvider/votesProvider.ts
@@ -2,24 +2,15 @@ import { getCurrentRound, getRoundBySlug, getSignupUsersByRound, getVoteResults,
 
 interface Props {
   roundSlug?: string;
-  roundId?: number;
 }
 
-export const votesProvider = async ({ roundSlug, roundId }: Props) => {
+export const votesProvider = async ({ roundSlug }: Props) => {
   try {
-    // If roundId is provided directly, use it
-    // Otherwise, get the round by slug or get the current round
-    let targetRoundId: number;
-    
-    if (roundId) {
-      targetRoundId = roundId;
-    } else {
-      const roundResult = roundSlug ? await getRoundBySlug(roundSlug) : await getCurrentRound();
-      if (roundResult.status !== 'success') {
-        throw new Error(`Failed to get round: ${roundResult.error?.message || 'Unknown error'}`);
-      }
-      targetRoundId = roundResult.data.roundId;
+    const roundResult = roundSlug ? await getRoundBySlug(roundSlug) : await getCurrentRound();
+    if (roundResult.status !== 'success') {
+      throw new Error(`Failed to get round: ${roundResult.error?.message || 'Unknown error'}`);
     }
+    const targetRoundId = roundResult.data.roundId;
 
     const voteResults = await getVoteResults(targetRoundId);
     const votingUserIds = await getVotingUsersByRound(targetRoundId);


### PR DESCRIPTION
## Changes
- Remove fallback to `roundId` when `slug` is not available in link generation
- Remove deprecated `getAllRoundIds` function from round service
- Simplify `votesProvider` to only use round slugs, removing `roundId` direct input option

## Why
- All rounds now have slugs, making the ID fallback unnecessary
- Streamlines routing and data access patterns to consistently use slugs
- Removes technical debt and simplifies the codebase

## Testing
- Verify all round links work correctly using slugs
- Ensure vote provider functions correctly with slug-based routing
- Check round navigation and display across all interfaces
