### PR TITLE
Enhanced Signup Experience for EPTS Round Participants - Allow changing of signup song

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 .sentryclirc
 
 backup.sql
+
+# windsurf rules
+.windsurfrules

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -4,6 +4,7 @@ import { Button, Card } from "@/components/ui/primitives";
 import Link from "next/link";
 import { Navigation } from "@/enum/navigation";
 import { Phase, RoundInfo } from "@/types/round";
+import { SignupData } from "@/types/signup";
 import { UserRoundParticipation } from "@/types/user";
 import { useEffect, useState } from "react";
 import { formatDate, formatTimeRemaining } from '@/services/dateService';
@@ -132,7 +133,9 @@ export function DashboardClient({ roundInfo, userRoundDetails, verificationStatu
   
   // Find the user's signup song if they've signed up
   const userSignup = isParticipating && phase === "signups" && roundInfo.signups ? 
-    roundInfo.signups.find((signup: any) => signup.userId === userRoundDetails.user.userid) : null;
+    roundInfo.signups.find((signup: SignupData) => 
+      signup.userId === userRoundDetails.user.userid
+    ) : null;
 
   const nextPhaseStartDate = dateLabels[nextPhase]?.opens;
 
@@ -221,7 +224,7 @@ export function DashboardClient({ roundInfo, userRoundDetails, verificationStatu
                 </p>
               ) : (
                 <p className="text-secondary">
-                  You've signed up, but we couldn't find your song details. You may want to update your submission.
+                  You&apos;ve signed up, but we couldn&apos;t find your song details. You may want to update your submission.
                 </p>
               )}
             </div>
@@ -230,9 +233,9 @@ export function DashboardClient({ roundInfo, userRoundDetails, verificationStatu
           {/* Explanation about voting responsibility */}
           {phase === "signups" && (
             <div className="mt-6 p-4 rounded-lg bg-background-tertiary border border-accent-tertiary">
-              <h3 className="text-lg font-medium text-primary mb-2">What's Next?</h3>
+              <h3 className="text-lg font-medium text-primary mb-2">What&apos;s Next?</h3>
               <p className="text-secondary">
-                Once the signup phase ends, you'll be responsible for voting on the cover options. 
+                Once the signup phase ends, you&apos;ll be responsible for voting on the cover options. 
                 Your vote helps determine which song will be selected for the round!
               </p>
             </div>

--- a/app/dashboard/DashboardClient.tsx
+++ b/app/dashboard/DashboardClient.tsx
@@ -70,7 +70,7 @@ const getActionButton = (
     case "signups":
       return {
         text: hasCompleted ? "Update Song Suggestion" : "Suggest a Song",
-        href: Navigation.SignUp,
+        href: hasCompleted ? `${Navigation.SignUp}?update=true` : Navigation.SignUp,
       };
     case "covering":
       return {
@@ -129,6 +129,10 @@ export function DashboardClient({ roundInfo, userRoundDetails, verificationStatu
 
   const currentPhaseEndDate = dateLabels[phase]?.closes;
   const nextPhase = getNextPhase(phase);
+  
+  // Find the user's signup song if they've signed up
+  const userSignup = isParticipating && phase === "signups" && roundInfo.signups ? 
+    roundInfo.signups.find((signup: any) => signup.userId === userRoundDetails.user.userid) : null;
 
   const nextPhaseStartDate = dateLabels[nextPhase]?.opens;
 
@@ -183,23 +187,56 @@ export function DashboardClient({ roundInfo, userRoundDetails, verificationStatu
       {/* Current Round Status */}
       <Card className="w-full p-8 bg-gray-900/50 border-gray-800 relative overflow-hidden backdrop-blur-xs mb-8">
         <div>
-          <h2 className="text-2xl font-semibold mb-8 text-gray-300">Current Round Progress</h2>
+          <h2 className="text-2xl font-semibold mb-8 text-primary">Current Round Progress</h2>
           <div className="grid gap-8 sm:grid-cols-2 md:grid-cols-2">
             <div className="space-y-4">
               <div>
                 <p className="text-[var(--color-accent-primary)] mb-2 text-lg">Phase</p>
-                <p className="text-xl text-gray-300 font-medium">{getPhaseTitle(phase)}</p>
+                <p className="text-xl text-primary font-medium">{getPhaseTitle(phase)}</p>
               </div>
+              {phase === "signups" && (
+                <div>
+                  <p className="text-[var(--color-accent-primary)] mb-2 text-lg">Current Signups</p>
+                  <p className="text-xl text-primary font-medium">{roundInfo.signups?.length || 0}</p>
+                </div>
+              )}
             </div>
             <div className="space-y-4">
               <div>
                 <p className="text-[var(--color-accent-primary)] mb-2 text-lg">Deadline</p>
-                <p className="text-xl text-gray-300 font-medium">
+                <p className="text-xl text-primary font-medium">
                   {currentPhaseEndDate ? formatDate.v(currentPhaseEndDate) : "TBD"}
                 </p>
               </div>
             </div>
           </div>
+          
+          {/* Show user's signup song if they've signed up during signup phase */}
+          {phase === "signups" && isParticipating && (
+            <div className="mt-6 p-4 rounded-lg bg-background-secondary border border-accent-secondary">
+              <h3 className="text-lg font-medium text-primary mb-2">Your Song Suggestion</h3>
+              {userSignup ? (
+                <p className="text-accent-primary">
+                  {userSignup.song?.title || 'Unknown'} by {userSignup.song?.artist || 'Unknown'}
+                </p>
+              ) : (
+                <p className="text-secondary">
+                  You've signed up, but we couldn't find your song details. You may want to update your submission.
+                </p>
+              )}
+            </div>
+          )}
+          
+          {/* Explanation about voting responsibility */}
+          {phase === "signups" && (
+            <div className="mt-6 p-4 rounded-lg bg-background-tertiary border border-accent-tertiary">
+              <h3 className="text-lg font-medium text-primary mb-2">What's Next?</h3>
+              <p className="text-secondary">
+                Once the signup phase ends, you'll be responsible for voting on the cover options. 
+                Your vote helps determine which song will be selected for the round!
+              </p>
+            </div>
+          )}
 
             <div className="mt-12 flex flex-col items-center p-10 bg-gray-900/70 rounded-lg border border-gray-800 relative overflow-hidden">
               <div className="absolute inset-0 bg-[url('/images/hero-pattern.svg')] opacity-5" />

--- a/app/sign-up/SharedSignupPageWrapper.tsx
+++ b/app/sign-up/SharedSignupPageWrapper.tsx
@@ -3,6 +3,9 @@ import { redirect } from "next/navigation";
 import { roundProvider, userParticipationProvider } from "@/providers";
 import { SignupPage } from "./SignupPage/SignupPage";
 import { getAuthUser } from "@/utils/supabase/server";
+import { db } from "@/db";
+import { signUps, songs } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
 
 interface SharedSignupPageWrapperProps {
   slug?: string;
@@ -35,6 +38,46 @@ export const SharedSignupPageWrapper = async ({
     roundId,
   });
   
+  // Fetch the user's existing signup data if they've already signed up
+  let userSignup = undefined;
+  if (isLoggedIn && userId && roundDetails?.hasSignedUp) {
+    const existingSignup = await db
+      .select({
+        songId: signUps.songId,
+        youtubeLink: signUps.youtubeLink,
+        additionalComments: signUps.additionalComments,
+      })
+      .from(signUps)
+      .where(
+        and(
+          eq(signUps.userId, userId),
+          eq(signUps.roundId, roundId)
+        )
+      )
+      .limit(1);
+
+    if (existingSignup.length > 0) {
+      // Get the song details
+      const songDetails = await db
+        .select({
+          title: songs.title,
+          artist: songs.artist,
+        })
+        .from(songs)
+        .where(eq(songs.id, existingSignup[0].songId))
+        .limit(1);
+
+      if (songDetails.length > 0) {
+        userSignup = {
+          songTitle: songDetails[0].title,
+          artist: songDetails[0].artist,
+          youtubeLink: existingSignup[0].youtubeLink,
+          additionalComments: existingSignup[0].additionalComments || undefined,
+        };
+      }
+    }
+  }
+  
   const signupsCloseDateLabel = dateLabels?.signups.closes;
 
   return (
@@ -44,6 +87,7 @@ export const SharedSignupPageWrapper = async ({
       hasSignedUp={roundDetails?.hasSignedUp || false}
       slug={slug || currentSlug}
       isLoggedIn={isLoggedIn}
+      userSignup={userSignup}
     />
   );
 };

--- a/app/sign-up/SharedSignupPageWrapper.tsx
+++ b/app/sign-up/SharedSignupPageWrapper.tsx
@@ -6,6 +6,7 @@ import { getAuthUser } from "@/utils/supabase/server";
 import { db } from "@/db";
 import { signUps, songs } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
+import { UserSignupData } from "@/types/signup";
 
 interface SharedSignupPageWrapperProps {
   slug?: string;
@@ -39,7 +40,7 @@ export const SharedSignupPageWrapper = async ({
   });
   
   // Fetch the user's existing signup data if they've already signed up
-  let userSignup = undefined;
+  let userSignup: UserSignupData | undefined = undefined;
   if (isLoggedIn && userId && roundDetails?.hasSignedUp) {
     const existingSignup = await db
       .select({

--- a/app/sign-up/SignupPage/SignupForm.tsx
+++ b/app/sign-up/SignupPage/SignupForm.tsx
@@ -13,6 +13,7 @@ import { signupSchema, nonLoggedInSchema, type SignupFormValues, type NonLoggedI
 import { useState } from "react"
 import { EmailConfirmationScreen } from "./EmailConfirmationScreen"
 import { useRouter } from "next/navigation"
+import { UserSignupData } from "@/types/signup"
 
 
 interface SignupFormProps {
@@ -21,12 +22,7 @@ interface SignupFormProps {
   onSuccess?: () => void;
   isLoggedIn?: boolean;
   isUpdate?: boolean;
-  existingSignup?: {
-    songTitle?: string;
-    artist?: string;
-    youtubeLink?: string;
-    additionalComments?: string;
-  };
+  existingSignup?: UserSignupData;
 }
 
 // Base fields for all users

--- a/app/sign-up/SignupPage/SignupForm.tsx
+++ b/app/sign-up/SignupPage/SignupForm.tsx
@@ -12,6 +12,7 @@ import { FormBuilder, FieldConfig } from "@/components/ui/form-fields/FormBuilde
 import { signupSchema, nonLoggedInSchema, type SignupFormValues, type NonLoggedInSignupFormValues } from "@/schemas/signupSchemas"
 import { useState } from "react"
 import { EmailConfirmationScreen } from "./EmailConfirmationScreen"
+import { useRouter } from "next/navigation"
 
 
 interface SignupFormProps {
@@ -19,6 +20,13 @@ interface SignupFormProps {
   signupsCloseDateLabel: string;
   onSuccess?: () => void;
   isLoggedIn?: boolean;
+  isUpdate?: boolean;
+  existingSignup?: {
+    songTitle?: string;
+    artist?: string;
+    youtubeLink?: string;
+    additionalComments?: string;
+  };
 }
 
 // Base fields for all users
@@ -77,10 +85,18 @@ const nonLoggedInFields: FieldConfig[] = [
   },
 ];
 
-export function SignupForm({ roundId, signupsCloseDateLabel, onSuccess, isLoggedIn = false }: SignupFormProps) {
+export function SignupForm({ 
+  roundId, 
+  signupsCloseDateLabel, 
+  onSuccess, 
+  isLoggedIn = false,
+  isUpdate = false,
+  existingSignup
+}: SignupFormProps) {
   // State to track if the form has been submitted (for non-logged in users)
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [submittedEmail, setSubmittedEmail] = useState("");
+  const router = useRouter();
   
   // Determine which schema and fields to use based on login status
   const schema = isLoggedIn ? signupSchema : nonLoggedInSchema;
@@ -89,10 +105,10 @@ export function SignupForm({ roundId, signupsCloseDateLabel, onSuccess, isLogged
   const form = useForm({
     resolver: zodResolver(schema),
     defaultValues: {
-      songTitle: "",
-      artist: "",
-      youtubeLink: "",
-      additionalComments: "",
+      songTitle: existingSignup?.songTitle || "",
+      artist: existingSignup?.artist || "",
+      youtubeLink: existingSignup?.youtubeLink || "",
+      additionalComments: existingSignup?.additionalComments || "",
       email: "",
       name: "",
       location: "",
@@ -124,13 +140,17 @@ export function SignupForm({ roundId, signupsCloseDateLabel, onSuccess, isLogged
     onSuccess: () => {
       if (!isLoggedIn) {
         setIsSubmitted(true);
-      }
-      if (onSuccess) {
+      } else if (isUpdate) {
+        // For updates, redirect to the success page
+        router.push(`/sign-up?success=true`);
+      } else if (onSuccess) {
         onSuccess();
       }
     },
     successMessage: isLoggedIn 
-      ? "You've successfully signed up for Everyone Plays the Same Song!" 
+      ? isUpdate 
+        ? "You've successfully updated your song for this round!" 
+        : "You've successfully signed up for Everyone Plays the Same Song!" 
       : "Please check your email for a verification link to complete your signup.",
   })
 
@@ -141,7 +161,9 @@ export function SignupForm({ roundId, signupsCloseDateLabel, onSuccess, isLogged
   
   return (
     <FormWrapper 
-      title={`Sign Up for Everyone Plays the Same Song round ${roundId}`}
+      title={isUpdate 
+        ? `Update Your Song for Round ${roundId}` 
+        : `Sign Up for Everyone Plays the Same Song round ${roundId}`}
       description={`Signups close ${signupsCloseDateLabel}${!isLoggedIn ? ' - Please provide your email to sign up' : ''}`}
       onSubmit={handleSubmit}
     >
@@ -190,7 +212,7 @@ export function SignupForm({ roundId, signupsCloseDateLabel, onSuccess, isLogged
             size="full"
             className="mt-4 py-3 text-lg font-medium shadow-md transition-all hover:shadow-lg focus:ring-2 focus:ring-accent-primary"
           >
-            {isLoading ? "Signing up..." : "Sign Up"}
+            {isLoading ? (isUpdate ? "Updating..." : "Signing up...") : (isUpdate ? "Update Song" : "Sign Up")}
           </Button>
         </motion.div>
       </Form>

--- a/app/sign-up/SignupPage/SignupPage.tsx
+++ b/app/sign-up/SignupPage/SignupPage.tsx
@@ -3,6 +3,7 @@
 import { PageTitle } from "@/components/PageTitle";
 import { ActionSuccessPanel } from "@/components/ActionSuccessPanel";
 import { SignupForm } from "./SignupForm";
+import { useSearchParams } from "next/navigation";
 
 interface Props {
   hasSignedUp: boolean;
@@ -10,6 +11,12 @@ interface Props {
   signupsCloseDateLabel: string;
   slug: string;
   isLoggedIn?: boolean;
+  userSignup?: {
+    songTitle?: string;
+    artist?: string;
+    youtubeLink?: string;
+    additionalComments?: string;
+  };
 }
 
 export function SignupPage({
@@ -18,8 +25,16 @@ export function SignupPage({
   signupsCloseDateLabel,
   slug,
   isLoggedIn = false,
+  userSignup,
 }: Props) {
-  const title = `Sign Up for Everyone Plays the Same Song round ${roundId}`;
+  // Check URL parameters
+  const searchParams = useSearchParams();
+  const isUpdate = searchParams?.get("update") === "true";
+  const showSuccess = searchParams?.get("success") === "true";
+  
+  const title = isUpdate 
+    ? `Update Your Song for Round ${roundId}` 
+    : `Sign Up for Everyone Plays the Same Song round ${roundId}`;
 
   const signupSuccessText = {
     header: `Thank you for signing up for round ${roundId} of Everyone Plays the Same Song!`,
@@ -39,7 +54,7 @@ export function SignupPage({
   return (
     <>
       <PageTitle title={title} />
-      {hasSignedUp ? (
+      {(hasSignedUp && !isUpdate) || showSuccess ? (
         <ActionSuccessPanel
           text={signupSuccessText}
           image={signupSuccessImage}
@@ -50,6 +65,8 @@ export function SignupPage({
           roundId={roundId}
           signupsCloseDateLabel={signupsCloseDateLabel}
           isLoggedIn={isLoggedIn}
+          isUpdate={hasSignedUp && isUpdate}
+          existingSignup={userSignup}
         />
       )}
     </>

--- a/app/sign-up/SignupPage/SignupPage.tsx
+++ b/app/sign-up/SignupPage/SignupPage.tsx
@@ -4,6 +4,7 @@ import { PageTitle } from "@/components/PageTitle";
 import { ActionSuccessPanel } from "@/components/ActionSuccessPanel";
 import { SignupForm } from "./SignupForm";
 import { useSearchParams } from "next/navigation";
+import { UserSignupData } from "@/types/signup";
 
 interface Props {
   hasSignedUp: boolean;
@@ -11,12 +12,7 @@ interface Props {
   signupsCloseDateLabel: string;
   slug: string;
   isLoggedIn?: boolean;
-  userSignup?: {
-    songTitle?: string;
-    artist?: string;
-    youtubeLink?: string;
-    additionalComments?: string;
-  };
+  userSignup?: UserSignupData;
 }
 
 export function SignupPage({

--- a/data-access/signupService.ts
+++ b/data-access/signupService.ts
@@ -28,20 +28,27 @@ export const getSignupsByRound = async (roundId: number) => {
     .where(eq(signUps.roundId, roundId))
     .orderBy(signUps.createdAt);
     
-    // Filter out entries with null userId or email and ensure all required fields are present
-    return data
-      .filter(val => val.userId !== null && val.email !== null)
-      .map(val => ({
+    // Process the data and throw errors for invalid entries
+    return data.map(val => {
+      if (!val.userId) {
+        throw new Error(`Signup for round ${roundId} has missing userId`);
+      }
+      if (!val.email) {
+        throw new Error(`Signup for round ${roundId} has missing email`);
+      }
+      
+      return {
         songId: val.songId,
         youtubeLink: val.youtubeLink,
-        userId: val.userId as string, // Type assertion since we've filtered out nulls
-        email: val.email as string, // Type assertion since we've filtered out nulls
+        userId: val.userId,
+        email: val.email,
         additionalComments: val.additionalComments || undefined,
         song: {
           title: val.song?.title || "",
           artist: val.song?.artist || ""
         }
-      }));
+      };
+    });
 };
 
 

--- a/data-access/signupService.ts
+++ b/data-access/signupService.ts
@@ -14,6 +14,7 @@ export const getSignupsByRound = async (roundId: number) => {
     .select({
       songId: signUps.songId,
       youtubeLink: signUps.youtubeLink,
+      additionalComments: signUps.additionalComments,
       song: {
         title: songs.title,
         artist: songs.artist
@@ -27,14 +28,20 @@ export const getSignupsByRound = async (roundId: number) => {
     .where(eq(signUps.roundId, roundId))
     .orderBy(signUps.createdAt);
     
-    return data.map((val) => ({
-      ...val,
-      song: {
-        title: val.song?.title || "",
-        artist: val.song?.artist || ""
-      }
-
-    }));
+    // Filter out entries with null userId or email and ensure all required fields are present
+    return data
+      .filter(val => val.userId !== null && val.email !== null)
+      .map(val => ({
+        songId: val.songId,
+        youtubeLink: val.youtubeLink,
+        userId: val.userId as string, // Type assertion since we've filtered out nulls
+        email: val.email as string, // Type assertion since we've filtered out nulls
+        additionalComments: val.additionalComments || undefined,
+        song: {
+          title: val.song?.title || "",
+          artist: val.song?.artist || ""
+        }
+      }));
 };
 
 

--- a/providers/roundProvider/roundProvider.ts
+++ b/providers/roundProvider/roundProvider.ts
@@ -1,7 +1,6 @@
 "use server";
 import {
   getCurrentRound,
-  getRoundById,
   getRoundBySlug,
   getRoundOverrideVotes,
   getSignupsByRound,

--- a/types/round.ts
+++ b/types/round.ts
@@ -1,5 +1,6 @@
 import { songs, roundMetadata, signUps } from "@/db/schema";
 import { InferSelectModel } from "drizzle-orm";
+import { SignupData } from "./signup";
 
 export type DBSong = InferSelectModel<typeof songs>;
 export type DBRound = InferSelectModel<typeof roundMetadata>;
@@ -18,6 +19,8 @@ export interface Submission {
   createdAt: Date;
 }
 
+// SignupData is now imported from ./signup
+
 export interface RoundInfo {
   roundId: DBRound["id"];
   slug: string;
@@ -35,7 +38,7 @@ export interface RoundInfo {
   }>;
   submissions: Submission[];
   playlistUrl?: string;
-  signups: { song: { title: string; artist: string; }; songId: number; youtubeLink: string; }[];
+  signups: SignupData[];
   // Add count properties
   signupCount?: number;
   submissionCount?: number;

--- a/types/signup.ts
+++ b/types/signup.ts
@@ -1,0 +1,53 @@
+/**
+ * Types related to user signups
+ */
+
+/**
+ * Base interface for song data
+ */
+export interface SongData {
+  title: string;
+  artist: string;
+}
+
+/**
+ * Interface for signup data as stored in the database and used in the API
+ */
+export interface SignupData {
+  songId: number;
+  youtubeLink: string;
+  userId: string;
+  email: string;
+  song: SongData;
+  additionalComments?: string;
+}
+
+/**
+ * Interface for user signup data displayed in the UI
+ */
+export interface UserSignupData {
+  songTitle?: string;
+  artist?: string;
+  youtubeLink?: string;
+  additionalComments?: string | undefined;
+}
+
+/**
+ * Interface for signup form values
+ */
+export interface SignupFormValues {
+  songTitle: string;
+  artist: string;
+  youtubeLink: string;
+  additionalComments?: string;
+  roundId: number;
+}
+
+/**
+ * Interface for non-logged in signup form values
+ */
+export interface NonLoggedInSignupFormValues extends SignupFormValues {
+  email: string;
+  name: string;
+  location?: string;
+}


### PR DESCRIPTION
This PR transforms our signup process from a one-time form submission into a more dynamic, user-friendly experience. It's a small change with big impact.

## What Changed

- **Song Updates**: Participants can now update their song suggestions during the signup phase
- **Visibility**: Users can see their current song suggestion directly on the dashboard
- **Context**: Added helpful guidance about what happens after signup phase ends
- **UI Improvements**: Enhanced dashboard with signup counts and better visual hierarchy
- **Data Integrity**: Improved error handling for signup data validation

## Why It Matters

The best communities give participants agency. This change transforms our signup process from a one-way street into a conversation. People change their minds. They discover better songs. Now they can update their choices without friction.

By showing users their current selection and what comes next, we're creating a more transparent, engaging experience that builds anticipation for the voting phase.

## Technical Notes

- Added new `UserSignupData` type and related interfaces
- Enhanced form handling to support both new signups and updates
- Improved data validation with better error messages
- Added `.windsurfrules` to gitignore

This change makes our platform more resilient while creating a more human experience for our community.
