### PR TITLE
Add Playwright integration test infrastructure

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -8,6 +8,12 @@
 # testing
 /coverage
 
+# Playwright
+/playwright-report/
+/playwright-results/
+/test-results/
+.playwright/
+
 # next.js
 /.next/
 /out/

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,13 @@
     "test:e2e:local": "bun start-server-and-test dev 3000 cypress:local",
     "test:e2e:staging": "cypress:staging",
     "test:e2e:production": "cypress:production",
+    "test:integration": "playwright test",
+    "test:integration:ui": "playwright test --ui",
+    "test:integration:headed": "playwright test --headed",
+    "test:integration:debug": "playwright test --debug",
+    "test:ct": "playwright test -c playwright-ct.config.ts",
+    "test:ct:ui": "playwright test -c playwright-ct.config.ts --ui",
+    "test:ct:debug": "playwright test -c playwright-ct.config.ts --debug",
     "clean": "rm -rf .next .turbo node_modules"
   },
   "dependencies": {
@@ -109,6 +116,8 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@playwright/experimental-ct-react": "^1.58.0",
+    "@playwright/test": "^1.58.0",
     "@tailwindcss/postcss": "^4.0.14",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
@@ -123,6 +132,7 @@
     "eslint": "8.26.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "playwright": "^1.58.0",
     "postcss": "8.4.35",
     "tailwindcss": "^4.1.17",
     "ts-node": "^10.9.2",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,87 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * EPTSS Integration Test Configuration
+ *
+ * This config is for page-level integration tests with mocked auth and API.
+ * For component tests, see playwright-ct.config.ts
+ */
+export default defineConfig({
+  testDir: './playwright/tests',
+
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+
+  /* Fail the build on CI if you accidentally left test.only in the source code */
+  forbidOnly: !!process.env.CI,
+
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+
+  /* Opt out of parallel tests on CI */
+  workers: process.env.CI ? 1 : undefined,
+
+  /* Reporter to use */
+  reporter: [
+    ['html', { outputFolder: 'playwright-report' }],
+    ['list'],
+  ],
+
+  /* Shared settings for all the projects below */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')` */
+    baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test */
+    trace: 'on-first-retry',
+
+    /* Take screenshot on failure */
+    screenshot: 'only-on-failure',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    // Uncomment to add more browsers:
+    // {
+    //   name: 'firefox',
+    //   use: { ...devices['Desktop Firefox'] },
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: { ...devices['Desktop Safari'] },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'PLAYWRIGHT_TEST_MODE=true PORT=3000 bun run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000, // 2 minutes to start the server
+    env: {
+      ...process.env, // Inherit all existing environment variables
+      PLAYWRIGHT_TEST_MODE: 'true',
+      PORT: '3000',
+      // Override with dummy values only for missing required vars
+      NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://test.supabase.co',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'test-anon-key',
+      SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY || 'test-service-role-key',
+      NEXT_RESEND_API_KEY: process.env.NEXT_RESEND_API_KEY || 'test-resend-key',
+    },
+  },
+
+  /* Test timeout */
+  timeout: 30 * 1000,
+
+  /* Expect timeout */
+  expect: {
+    timeout: 5 * 1000,
+  },
+
+  /* Output folder for test artifacts */
+  outputDir: 'playwright-results',
+});

--- a/apps/web/playwright/components/ActionSuccessPanel.spec.tsx
+++ b/apps/web/playwright/components/ActionSuccessPanel.spec.tsx
@@ -1,0 +1,66 @@
+/**
+ * ActionSuccessPanel Component Tests
+ *
+ * Tests the success panel component in isolation
+ *
+ * Note: Component testing with Next.js requires additional setup for:
+ * - next/image
+ * - next/link
+ * - Package imports (@eptss/*)
+ *
+ * These tests serve as examples and may need adjustments based on
+ * your specific build configuration.
+ */
+
+import { test, expect } from '@playwright/experimental-ct-react';
+
+// For component tests, we need to import the component directly
+// However, Next.js components with dependencies may need mocking
+
+test.describe('ActionSuccessPanel', () => {
+  test.skip('renders with provided text content', async ({ mount }) => {
+    // This test is skipped because it requires additional setup for Next.js
+    // component testing with @eptss/* packages and next/image
+    //
+    // To enable:
+    // 1. Configure vite/webpack in playwright-ct.config.ts to resolve aliases
+    // 2. Mock next/image and next/link in playwright/index.tsx
+    // 3. Ensure @eptss/ui components are bundled correctly
+  });
+
+  test.skip('shows correct action button text for signups', async ({ mount }) => {
+    // Test the button text changes based on action prop
+  });
+
+  test.skip('shows Home button when no action specified', async ({ mount }) => {
+    // Test default button behavior
+  });
+});
+
+/**
+ * Example of how a fully working component test would look:
+ *
+ * ```tsx
+ * test('renders success message', async ({ mount }) => {
+ *   const component = await mount(
+ *     <ActionSuccessPanel
+ *       text={{
+ *         header: "Success!",
+ *         body: "Your action was completed.",
+ *         thankyou: "Thank you for participating!"
+ *       }}
+ *       image={{
+ *         src: "/test-image.jpg",
+ *         alt: "Success image"
+ *       }}
+ *       roundId={1}
+ *       projectSlug="cover"
+ *     />
+ *   );
+ *
+ *   await expect(component.getByText('Success!')).toBeVisible();
+ *   await expect(component.getByText('Your action was completed.')).toBeVisible();
+ *   await expect(component.getByRole('button', { name: 'Home' })).toBeVisible();
+ * });
+ * ```
+ */

--- a/apps/web/playwright/components/example.spec.tsx
+++ b/apps/web/playwright/components/example.spec.tsx
@@ -1,0 +1,184 @@
+/**
+ * Example Component Tests
+ *
+ * This file demonstrates how to write Playwright component tests
+ * using simple React components that don't have external dependencies.
+ */
+
+import { test, expect } from '@playwright/experimental-ct-react';
+import React from 'react';
+
+/**
+ * Simple test component with no external dependencies
+ */
+function TestButton({
+  label,
+  onClick,
+  disabled = false,
+}: {
+  label: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className="px-4 py-2 bg-blue-500 text-white rounded disabled:opacity-50"
+    >
+      {label}
+    </button>
+  );
+}
+
+/**
+ * Simple badge component for testing
+ */
+function TestBadge({ count }: { count: number }) {
+  if (count === 0) return null;
+
+  return (
+    <span
+      data-testid="badge"
+      className="inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-white bg-red-600 rounded-full"
+    >
+      {count > 99 ? '99+' : count}
+    </span>
+  );
+}
+
+/**
+ * Card component example
+ */
+function TestCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="border rounded-lg p-4 shadow-sm">
+      <h2 className="text-lg font-semibold">{title}</h2>
+      {description && <p className="text-gray-600 mt-1">{description}</p>}
+      {children && <div className="mt-4">{children}</div>}
+    </div>
+  );
+}
+
+test.describe('TestButton Component', () => {
+  test('renders with label', async ({ mount }) => {
+    const component = await mount(<TestButton label="Click me" />);
+
+    await expect(component.getByRole('button')).toHaveText('Click me');
+  });
+
+  test('handles click events', async ({ mount }) => {
+    let clicked = false;
+    const component = await mount(
+      <TestButton label="Click me" onClick={() => (clicked = true)} />
+    );
+
+    await component.getByRole('button').click();
+
+    // Note: In component tests, we can't easily verify external state changes
+    // This test verifies the button is clickable
+    await expect(component.getByRole('button')).toBeEnabled();
+  });
+
+  test('can be disabled', async ({ mount }) => {
+    const component = await mount(<TestButton label="Disabled" disabled={true} />);
+
+    await expect(component.getByRole('button')).toBeDisabled();
+  });
+
+  test('applies disabled styles', async ({ mount }) => {
+    const component = await mount(<TestButton label="Disabled" disabled={true} />);
+
+    // Check that the disabled class is applied (opacity)
+    const button = component.getByRole('button');
+    await expect(button).toHaveClass(/disabled:opacity-50/);
+  });
+});
+
+test.describe('TestBadge Component', () => {
+  test('shows count when greater than 0', async ({ mount }) => {
+    const component = await mount(<TestBadge count={5} />);
+
+    await expect(component.getByTestId('badge')).toBeVisible();
+    await expect(component.getByTestId('badge')).toHaveText('5');
+  });
+
+  test('hides when count is 0', async ({ mount }) => {
+    const component = await mount(<TestBadge count={0} />);
+
+    await expect(component.getByTestId('badge')).not.toBeVisible();
+  });
+
+  test('shows 99+ for large counts', async ({ mount }) => {
+    const component = await mount(<TestBadge count={150} />);
+
+    await expect(component.getByTestId('badge')).toHaveText('99+');
+  });
+
+  test('shows exact count at boundary (99)', async ({ mount }) => {
+    const component = await mount(<TestBadge count={99} />);
+
+    await expect(component.getByTestId('badge')).toHaveText('99');
+  });
+});
+
+test.describe('TestCard Component', () => {
+  test('renders title', async ({ mount }) => {
+    const component = await mount(<TestCard title="My Card" />);
+
+    await expect(component.getByRole('heading')).toHaveText('My Card');
+  });
+
+  test('renders title and description', async ({ mount }) => {
+    const component = await mount(
+      <TestCard title="My Card" description="This is a description" />
+    );
+
+    await expect(component.getByRole('heading')).toHaveText('My Card');
+    await expect(component.getByText('This is a description')).toBeVisible();
+  });
+
+  test('renders children content', async ({ mount }) => {
+    const component = await mount(
+      <TestCard title="My Card">
+        <span data-testid="child-content">Child content here</span>
+      </TestCard>
+    );
+
+    await expect(component.getByTestId('child-content')).toBeVisible();
+  });
+
+  test('does not render description when not provided', async ({ mount }) => {
+    const component = await mount(<TestCard title="My Card" />);
+
+    // Only the heading should be visible, no paragraph
+    await expect(component.getByRole('heading')).toBeVisible();
+    await expect(component.locator('p')).not.toBeVisible();
+  });
+});
+
+test.describe('Component Composition', () => {
+  test('can compose multiple components', async ({ mount }) => {
+    const component = await mount(
+      <TestCard title="Notifications">
+        <div className="flex items-center gap-2">
+          <span>Unread:</span>
+          <TestBadge count={3} />
+        </div>
+        <TestButton label="Mark all as read" />
+      </TestCard>
+    );
+
+    await expect(component.getByRole('heading')).toHaveText('Notifications');
+    await expect(component.getByTestId('badge')).toHaveText('3');
+    await expect(component.getByRole('button')).toHaveText('Mark all as read');
+  });
+});

--- a/apps/web/playwright/fixtures/api.fixture.ts
+++ b/apps/web/playwright/fixtures/api.fixture.ts
@@ -1,0 +1,259 @@
+/**
+ * API fixture for Playwright integration tests
+ *
+ * Provides utilities for mocking API routes and network requests
+ */
+
+import { test as base, Page, Route } from '@playwright/test';
+import { MockRound, mockRounds, createMockRound } from '../mocks/api/rounds';
+import {
+  MockNotification,
+  createMockNotificationList,
+} from '../mocks/api/notifications';
+
+/**
+ * Extended test fixtures with API mocking capabilities
+ */
+export interface ApiFixtures {
+  /**
+   * Mock API utilities
+   */
+  mockApi: {
+    /**
+     * Mock the /api/rounds endpoint
+     */
+    rounds: (data?: MockRound[]) => Promise<void>;
+
+    /**
+     * Mock the /api/round-info endpoint
+     */
+    roundInfo: (data?: Partial<MockRound> | null) => Promise<void>;
+
+    /**
+     * Mock the /api/round/current endpoint
+     */
+    currentRound: (data?: Partial<MockRound> | null) => Promise<void>;
+
+    /**
+     * Mock the /api/notifications endpoint
+     */
+    notifications: (data?: MockNotification[]) => Promise<void>;
+
+    /**
+     * Mock the /api/notifications/unread-count endpoint
+     */
+    unreadNotificationCount: (count?: number) => Promise<void>;
+
+    /**
+     * Mock a custom route with a handler
+     */
+    custom: (pattern: string, handler: (route: Route) => Promise<void>) => Promise<void>;
+
+    /**
+     * Mock a route to fail with a specific status
+     */
+    failWith: (pattern: string, status: number, error?: string) => Promise<void>;
+
+    /**
+     * Mock Supabase storage URLs
+     */
+    mockStorage: () => Promise<void>;
+
+    /**
+     * Clear all route mocks
+     */
+    clearAll: () => Promise<void>;
+  };
+}
+
+/**
+ * Create the API fixture
+ */
+export const apiFixture = base.extend<ApiFixtures>({
+  mockApi: async ({ page }: { page: Page }, use) => {
+    // Track mocked routes for cleanup
+    const mockedRoutes: string[] = [];
+
+    const mockApi = {
+      /**
+       * Mock /api/rounds
+       */
+      rounds: async (data?: MockRound[]) => {
+        const pattern = '**/api/rounds';
+        mockedRoutes.push(pattern);
+
+        await page.route(pattern, async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(data ?? [mockRounds.coveringPhase]),
+          });
+        });
+      },
+
+      /**
+       * Mock /api/round-info
+       */
+      roundInfo: async (data?: Partial<MockRound> | null) => {
+        const pattern = '**/api/round-info**';
+        mockedRoutes.push(pattern);
+
+        await page.route(pattern, async (route) => {
+          if (data === null) {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({ currentRound: null }),
+            });
+          } else {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({
+                currentRound: createMockRound(data),
+              }),
+            });
+          }
+        });
+      },
+
+      /**
+       * Mock /api/round/current
+       */
+      currentRound: async (data?: Partial<MockRound> | null) => {
+        const pattern = '**/api/round/current**';
+        mockedRoutes.push(pattern);
+
+        await page.route(pattern, async (route) => {
+          if (data === null) {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify(null),
+            });
+          } else {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify(createMockRound(data)),
+            });
+          }
+        });
+      },
+
+      /**
+       * Mock /api/notifications
+       */
+      notifications: async (data?: MockNotification[]) => {
+        const pattern = '**/api/notifications';
+        mockedRoutes.push(pattern);
+
+        await page.route(pattern, async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              notifications: data ?? createMockNotificationList(5),
+            }),
+          });
+        });
+      },
+
+      /**
+       * Mock /api/notifications/unread-count
+       */
+      unreadNotificationCount: async (count = 3) => {
+        const pattern = '**/api/notifications/unread-count';
+        mockedRoutes.push(pattern);
+
+        await page.route(pattern, async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ count }),
+          });
+        });
+      },
+
+      /**
+       * Mock a custom route
+       */
+      custom: async (pattern: string, handler: (route: Route) => Promise<void>) => {
+        mockedRoutes.push(pattern);
+        await page.route(pattern, handler);
+      },
+
+      /**
+       * Mock a route to fail
+       */
+      failWith: async (pattern: string, status: number, error = 'Internal Server Error') => {
+        mockedRoutes.push(pattern);
+
+        await page.route(pattern, async (route) => {
+          await route.fulfill({
+            status,
+            contentType: 'application/json',
+            body: JSON.stringify({ error }),
+          });
+        });
+      },
+
+      /**
+       * Mock Supabase storage for audio files and images
+       */
+      mockStorage: async () => {
+        const storagePattern = '**/*.supabase.co/storage/**';
+        mockedRoutes.push(storagePattern);
+
+        await page.route(storagePattern, async (route) => {
+          const url = route.request().url();
+
+          // Return a small placeholder based on file type
+          if (url.includes('.mp3') || url.includes('.wav') || url.includes('.m4a')) {
+            // Return empty audio for audio files
+            await route.fulfill({
+              status: 200,
+              contentType: 'audio/mpeg',
+              body: Buffer.from([]),
+            });
+          } else if (
+            url.includes('.jpg') ||
+            url.includes('.jpeg') ||
+            url.includes('.png') ||
+            url.includes('.webp')
+          ) {
+            // Return a 1x1 transparent PNG for images
+            await route.fulfill({
+              status: 200,
+              contentType: 'image/png',
+              body: Buffer.from(
+                'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+                'base64'
+              ),
+            });
+          } else {
+            // Default: continue with request
+            await route.continue();
+          }
+        });
+      },
+
+      /**
+       * Clear all mocked routes
+       */
+      clearAll: async () => {
+        for (const pattern of mockedRoutes) {
+          await page.unroute(pattern);
+        }
+        mockedRoutes.length = 0;
+      },
+    };
+
+    await use(mockApi);
+
+    // Cleanup: unroute all mocked routes after test
+    await mockApi.clearAll();
+  },
+});
+
+export { apiFixture as test };

--- a/apps/web/playwright/fixtures/auth.fixture.ts
+++ b/apps/web/playwright/fixtures/auth.fixture.ts
@@ -1,0 +1,108 @@
+/**
+ * Auth fixture for Playwright integration tests
+ *
+ * Provides a `loginAs` function that injects Supabase auth cookies
+ * to simulate authenticated users without hitting the real auth service.
+ */
+
+import { test as base, BrowserContext, Page } from '@playwright/test';
+import { MockUser, mockUsers, MockUserKey } from '../mocks/auth/users';
+import { getSupabaseCookies } from '../mocks/auth/session';
+
+/**
+ * Extended test fixtures with auth capabilities
+ */
+export interface AuthFixtures {
+  /**
+   * Login as a specific mock user by injecting auth cookies
+   * Can accept a MockUser object or a key from mockUsers
+   */
+  loginAs: (userOrKey: MockUser | MockUserKey) => Promise<void>;
+
+  /**
+   * Clear all auth cookies to simulate logged out state
+   */
+  logout: () => Promise<void>;
+
+  /**
+   * Check if currently authenticated (has auth cookies)
+   */
+  isAuthenticated: () => Promise<boolean>;
+}
+
+/**
+ * Create the auth fixture
+ */
+export const authFixture = base.extend<AuthFixtures>({
+  /**
+   * loginAs - Inject auth cookies for a mock user
+   */
+  loginAs: async ({ context }: { context: BrowserContext }, use) => {
+    const loginAs = async (userOrKey: MockUser | MockUserKey) => {
+      // Resolve user from key or use directly
+      const user: MockUser =
+        typeof userOrKey === 'string' ? mockUsers[userOrKey] : userOrKey;
+
+      if (!user) {
+        throw new Error(
+          `Invalid user or user key: ${userOrKey}. Available keys: ${Object.keys(mockUsers).join(', ')}`
+        );
+      }
+
+      // Get the cookies for this user
+      const cookies = getSupabaseCookies(user);
+
+      // Add cookies to the browser context
+      await context.addCookies(cookies);
+    };
+
+    await use(loginAs);
+  },
+
+  /**
+   * logout - Clear auth cookies
+   */
+  logout: async ({ context }: { context: BrowserContext }, use) => {
+    const logout = async () => {
+      // Get all cookies and filter out auth-related ones
+      const cookies = await context.cookies();
+
+      // Find and clear Supabase auth cookies
+      const authCookiePattern = /^sb-.*-auth-token/;
+      const authCookies = cookies.filter((c) => authCookiePattern.test(c.name));
+
+      // Clear each auth cookie by setting it to expired
+      for (const cookie of authCookies) {
+        await context.addCookies([
+          {
+            name: cookie.name,
+            value: '',
+            domain: cookie.domain,
+            path: cookie.path,
+            expires: 0,
+          },
+        ]);
+      }
+
+      // Also clear the entire context cookies as fallback
+      await context.clearCookies();
+    };
+
+    await use(logout);
+  },
+
+  /**
+   * isAuthenticated - Check if auth cookies exist
+   */
+  isAuthenticated: async ({ context }: { context: BrowserContext }, use) => {
+    const isAuthenticated = async (): Promise<boolean> => {
+      const cookies = await context.cookies();
+      const authCookiePattern = /^sb-.*-auth-token/;
+      return cookies.some((c) => authCookiePattern.test(c.name));
+    };
+
+    await use(isAuthenticated);
+  },
+});
+
+export { authFixture as test };

--- a/apps/web/playwright/fixtures/index.ts
+++ b/apps/web/playwright/fixtures/index.ts
@@ -1,0 +1,265 @@
+/**
+ * Combined Playwright fixtures for EPTSS integration tests
+ *
+ * This file combines auth and API fixtures into a single extended test
+ * that can be used throughout the test suite.
+ *
+ * Usage:
+ *   import { test, expect } from '../fixtures';
+ *
+ *   test('my test', async ({ page, loginAs, mockApi }) => {
+ *     await loginAs('regular');
+ *     await mockApi.roundInfo({ phase: 'covering' });
+ *     await page.goto('/dashboard');
+ *     // ...
+ *   });
+ */
+
+import { test as base, expect } from '@playwright/test';
+import { Route } from '@playwright/test';
+import { MockUser, mockUsers, MockUserKey } from '../mocks/auth/users';
+import { MockRound, mockRounds, createMockRound } from '../mocks/api/rounds';
+import {
+  MockNotification,
+  createMockNotificationList,
+} from '../mocks/api/notifications';
+
+/**
+ * Cookie name for test authentication (must match testAuthBypass.ts)
+ */
+const TEST_AUTH_COOKIE_NAME = '__playwright_test_auth';
+
+/**
+ * Combined fixtures interface
+ */
+interface Fixtures {
+  // Auth fixtures
+  loginAs: (userOrKey: MockUser | MockUserKey) => Promise<void>;
+  logout: () => Promise<void>;
+  isAuthenticated: () => Promise<boolean>;
+
+  // API fixtures (for client-side requests)
+  mockApi: {
+    rounds: (data?: MockRound[]) => Promise<void>;
+    roundInfo: (data?: Partial<MockRound> | null) => Promise<void>;
+    currentRound: (data?: Partial<MockRound> | null) => Promise<void>;
+    notifications: (data?: MockNotification[]) => Promise<void>;
+    unreadNotificationCount: (count?: number) => Promise<void>;
+    custom: (pattern: string, handler: (route: Route) => Promise<void>) => Promise<void>;
+    failWith: (pattern: string, status: number, error?: string) => Promise<void>;
+    mockStorage: () => Promise<void>;
+    clearAll: () => Promise<void>;
+  };
+}
+
+/**
+ * Extended test with all fixtures
+ */
+export const test = base.extend<Fixtures>({
+  // ============================================
+  // AUTH FIXTURES
+  // ============================================
+
+  loginAs: async ({ context }, use) => {
+    const loginAs = async (userOrKey: MockUser | MockUserKey) => {
+      const user: MockUser =
+        typeof userOrKey === 'string' ? mockUsers[userOrKey] : userOrKey;
+
+      if (!user) {
+        throw new Error(
+          `Invalid user or user key: ${userOrKey}. Available keys: ${Object.keys(mockUsers).join(', ')}`
+        );
+      }
+
+      // Set the test auth cookie that the middleware will recognize
+      // This bypasses Supabase auth when PLAYWRIGHT_TEST_MODE=true
+      await context.addCookies([
+        {
+          name: TEST_AUTH_COOKIE_NAME,
+          value: JSON.stringify({
+            id: user.id,
+            email: user.email,
+            username: user.username,
+            adminLevel: user.adminLevel,
+          }),
+          domain: 'localhost',
+          path: '/',
+          httpOnly: false,
+          secure: false,
+          sameSite: 'Lax',
+        },
+      ]);
+    };
+
+    await use(loginAs);
+  },
+
+  logout: async ({ context }, use) => {
+    const logout = async () => {
+      await context.clearCookies();
+    };
+
+    await use(logout);
+  },
+
+  isAuthenticated: async ({ context }, use) => {
+    const isAuthenticated = async (): Promise<boolean> => {
+      const cookies = await context.cookies();
+      return cookies.some((c) => c.name === TEST_AUTH_COOKIE_NAME);
+    };
+
+    await use(isAuthenticated);
+  },
+
+  // ============================================
+  // API FIXTURES (for client-side requests)
+  // ============================================
+
+  mockApi: async ({ page }, use) => {
+    const mockedRoutes: string[] = [];
+
+    const mockApi = {
+      rounds: async (data?: MockRound[]) => {
+        const pattern = '**/api/rounds';
+        mockedRoutes.push(pattern);
+        await page.route(pattern, async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(data ?? [mockRounds.coveringPhase]),
+          });
+        });
+      },
+
+      roundInfo: async (data?: Partial<MockRound> | null) => {
+        const pattern = '**/api/round-info**';
+        mockedRoutes.push(pattern);
+        await page.route(pattern, async (route) => {
+          if (data === null) {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({ currentRound: null }),
+            });
+          } else {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({ currentRound: createMockRound(data) }),
+            });
+          }
+        });
+      },
+
+      currentRound: async (data?: Partial<MockRound> | null) => {
+        const pattern = '**/api/round/current**';
+        mockedRoutes.push(pattern);
+        await page.route(pattern, async (route) => {
+          if (data === null) {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify(null),
+            });
+          } else {
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify(createMockRound(data)),
+            });
+          }
+        });
+      },
+
+      notifications: async (data?: MockNotification[]) => {
+        const pattern = '**/api/notifications';
+        mockedRoutes.push(pattern);
+        await page.route(pattern, async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              notifications: data ?? createMockNotificationList(5),
+            }),
+          });
+        });
+      },
+
+      unreadNotificationCount: async (count = 3) => {
+        const pattern = '**/api/notifications/unread-count';
+        mockedRoutes.push(pattern);
+        await page.route(pattern, async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ count }),
+          });
+        });
+      },
+
+      custom: async (pattern: string, handler: (route: Route) => Promise<void>) => {
+        mockedRoutes.push(pattern);
+        await page.route(pattern, handler);
+      },
+
+      failWith: async (pattern: string, status: number, error = 'Internal Server Error') => {
+        mockedRoutes.push(pattern);
+        await page.route(pattern, async (route) => {
+          await route.fulfill({
+            status,
+            contentType: 'application/json',
+            body: JSON.stringify({ error }),
+          });
+        });
+      },
+
+      mockStorage: async () => {
+        const storagePattern = '**/*.supabase.co/storage/**';
+        mockedRoutes.push(storagePattern);
+        await page.route(storagePattern, async (route) => {
+          const url = route.request().url();
+          if (url.includes('.mp3') || url.includes('.wav') || url.includes('.m4a')) {
+            await route.fulfill({
+              status: 200,
+              contentType: 'audio/mpeg',
+              body: Buffer.from([]),
+            });
+          } else if (
+            url.includes('.jpg') ||
+            url.includes('.jpeg') ||
+            url.includes('.png') ||
+            url.includes('.webp')
+          ) {
+            await route.fulfill({
+              status: 200,
+              contentType: 'image/png',
+              body: Buffer.from(
+                'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+                'base64'
+              ),
+            });
+          } else {
+            await route.continue();
+          }
+        });
+      },
+
+      clearAll: async () => {
+        for (const pattern of mockedRoutes) {
+          await page.unroute(pattern);
+        }
+        mockedRoutes.length = 0;
+      },
+    };
+
+    await use(mockApi);
+    await mockApi.clearAll();
+  },
+});
+
+// Re-export expect from Playwright
+export { expect };
+
+// Re-export mock data for convenience
+export { mockUsers, mockRounds };
+export type { MockUser, MockRound, MockNotification };

--- a/apps/web/playwright/index.tsx
+++ b/apps/web/playwright/index.tsx
@@ -1,0 +1,51 @@
+/**
+ * Playwright Component Testing Hooks
+ *
+ * This file provides hooks for setting up the component testing environment.
+ * It's used to mock Next.js features and provide necessary context to components.
+ */
+
+import { beforeMount, afterMount } from '@playwright/experimental-ct-react/hooks';
+
+// Mock Next.js navigation hooks
+const mockRouter = {
+  push: async (url: string) => {
+    console.log('[Mock Router] push:', url);
+  },
+  replace: async (url: string) => {
+    console.log('[Mock Router] replace:', url);
+  },
+  refresh: () => {
+    console.log('[Mock Router] refresh');
+  },
+  back: () => {
+    console.log('[Mock Router] back');
+  },
+  forward: () => {
+    console.log('[Mock Router] forward');
+  },
+  prefetch: async (url: string) => {
+    console.log('[Mock Router] prefetch:', url);
+  },
+};
+
+// Type for hook configuration
+export interface HooksConfig {
+  router?: typeof mockRouter;
+  pathname?: string;
+  searchParams?: Record<string, string>;
+}
+
+beforeMount<HooksConfig>(async ({ App, hooksConfig }) => {
+  // Set up any global providers or mocks here
+  // The hooksConfig object contains configuration passed from tests
+
+  // Example: You can wrap the App with providers here
+  // return <SomeProvider>{App}</SomeProvider>;
+});
+
+afterMount<HooksConfig>(async () => {
+  // Cleanup after mount if needed
+});
+
+export { mockRouter };

--- a/apps/web/playwright/mocks/api/notifications.ts
+++ b/apps/web/playwright/mocks/api/notifications.ts
@@ -1,0 +1,145 @@
+/**
+ * Mock notification data for integration tests
+ *
+ * Matches the Notification type from the codebase
+ */
+
+export type NotificationType =
+  | 'signup_confirmation'
+  | 'vote_confirmation'
+  | 'submission_confirmation'
+  | 'round_opened'
+  | 'round_voting_opened'
+  | 'round_covering_begins'
+  | 'round_covers_due'
+  | 'comment_received'
+  | 'comment_reply_received'
+  | 'comment_upvoted'
+  | 'mention_received'
+  | 'admin_announcement'
+  | 'test_notification';
+
+export interface MockNotification {
+  id: string;
+  userId: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  metadata?: string | null;
+  isRead: boolean;
+  isDeleted: boolean;
+  createdAt: Date;
+  readAt?: Date | null;
+}
+
+/**
+ * Create a mock notification with sensible defaults
+ */
+export function createMockNotification(
+  overrides: Partial<MockNotification> = {}
+): MockNotification {
+  return {
+    id: overrides.id ?? crypto.randomUUID(),
+    userId: overrides.userId ?? '11111111-1111-1111-1111-111111111111',
+    type: overrides.type ?? 'round_opened',
+    title: overrides.title ?? 'Test Notification',
+    message: overrides.message ?? 'This is a test notification message.',
+    metadata: overrides.metadata ?? null,
+    isRead: overrides.isRead ?? false,
+    isDeleted: overrides.isDeleted ?? false,
+    createdAt: overrides.createdAt ?? new Date(),
+    readAt: overrides.readAt ?? null,
+  };
+}
+
+/**
+ * Pre-defined mock notifications for common test scenarios
+ */
+export const mockNotifications = {
+  /**
+   * Unread round notification
+   */
+  unreadRoundOpened: createMockNotification({
+    id: 'notif-1',
+    type: 'round_opened',
+    title: 'New Round Started!',
+    message: 'Round 12 has opened. Sign up now!',
+    metadata: JSON.stringify({ roundId: 12, roundSlug: 'round-12' }),
+    isRead: false,
+  }),
+
+  /**
+   * Read signup confirmation
+   */
+  readSignupConfirmation: createMockNotification({
+    id: 'notif-2',
+    type: 'signup_confirmation',
+    title: 'Signup Confirmed',
+    message: 'You have successfully signed up for Round 12.',
+    metadata: JSON.stringify({ roundId: 12 }),
+    isRead: true,
+    readAt: new Date(Date.now() - 24 * 60 * 60 * 1000), // 1 day ago
+  }),
+
+  /**
+   * Comment received notification
+   */
+  commentReceived: createMockNotification({
+    id: 'notif-3',
+    type: 'comment_received',
+    title: 'New Comment',
+    message: 'Someone commented on your reflection.',
+    metadata: JSON.stringify({ contentId: 'content-123', commentId: 'comment-456' }),
+    isRead: false,
+  }),
+
+  /**
+   * Admin announcement
+   */
+  adminAnnouncement: createMockNotification({
+    id: 'notif-4',
+    type: 'admin_announcement',
+    title: 'Important Update',
+    message: 'We have updated the submission guidelines.',
+    isRead: false,
+  }),
+
+  /**
+   * Submission confirmation
+   */
+  submissionConfirmation: createMockNotification({
+    id: 'notif-5',
+    type: 'submission_confirmation',
+    title: 'Submission Received',
+    message: 'Your cover has been submitted for Round 12.',
+    metadata: JSON.stringify({ roundId: 12, submissionId: 'sub-123' }),
+    isRead: true,
+    readAt: new Date(),
+  }),
+};
+
+/**
+ * Create a list of mock notifications
+ */
+export function createMockNotificationList(count = 5): MockNotification[] {
+  const types: NotificationType[] = [
+    'round_opened',
+    'signup_confirmation',
+    'comment_received',
+    'submission_confirmation',
+    'round_voting_opened',
+  ];
+
+  return Array.from({ length: count }, (_, i) =>
+    createMockNotification({
+      id: `notif-list-${i}`,
+      type: types[i % types.length],
+      title: `Notification ${i + 1}`,
+      message: `This is notification number ${i + 1}.`,
+      isRead: i < 2, // First 2 are read
+      createdAt: new Date(Date.now() - i * 60 * 60 * 1000), // Staggered by 1 hour
+    })
+  );
+}
+
+export type MockNotificationKey = keyof typeof mockNotifications;

--- a/apps/web/playwright/mocks/api/rounds.ts
+++ b/apps/web/playwright/mocks/api/rounds.ts
@@ -1,0 +1,264 @@
+/**
+ * Mock round data for integration tests
+ *
+ * Matches the RoundInfo type from the codebase
+ */
+
+export type Phase = 'signups' | 'voting' | 'covering' | 'celebration';
+
+export interface DateLabel {
+  opens: string;
+  closes: string;
+}
+
+export interface MockSong {
+  id: number;
+  title: string;
+  artist: string;
+}
+
+export interface MockSubmission {
+  roundId: number;
+  username: string;
+  publicDisplayName?: string | null;
+  userId: string;
+  createdAt: Date;
+  soundcloudUrl?: string | null;
+  audioFileUrl?: string | null;
+  coverImageUrl?: string | null;
+  audioDuration?: number | null;
+  audioFileSize?: number | null;
+}
+
+export interface MockSignup {
+  id: number;
+  userId: string;
+  username: string;
+  publicDisplayName?: string | null;
+  roundId: number;
+  songId?: number | null;
+  youtubeLink?: string | null;
+  additionalComments?: string | null;
+  createdAt: Date;
+}
+
+export interface MockVoteOption {
+  roundId: number;
+  songId: number;
+  youtubeLink?: string;
+  song: Pick<MockSong, 'title' | 'artist'>;
+}
+
+export interface MockRound {
+  roundId: number;
+  slug: string;
+  phase: Phase;
+  song: Pick<MockSong, 'title' | 'artist'>;
+  dateLabels: Record<Phase, DateLabel>;
+  hasRoundStarted: boolean;
+  areSubmissionsOpen: boolean;
+  isVotingOpen: boolean;
+  voteOptions: MockVoteOption[];
+  submissions: MockSubmission[];
+  playlistUrl?: string;
+  signups: MockSignup[];
+  signupCount?: number;
+  submissionCount?: number;
+  signupOpens: Date;
+  votingOpens: Date;
+  coveringBegins: Date;
+  coversDue: Date;
+  listeningParty: Date;
+  votingEnabled: boolean;
+}
+
+/**
+ * Create mock date labels for a phase
+ */
+function createDateLabels(baseDate: Date): Record<Phase, DateLabel> {
+  const formatDate = (date: Date) =>
+    date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+
+  const signupOpens = new Date(baseDate);
+  const votingOpens = new Date(baseDate.getTime() + 7 * 24 * 60 * 60 * 1000); // +7 days
+  const coveringBegins = new Date(baseDate.getTime() + 14 * 24 * 60 * 60 * 1000); // +14 days
+  const coversDue = new Date(baseDate.getTime() + 28 * 24 * 60 * 60 * 1000); // +28 days
+  const listeningParty = new Date(baseDate.getTime() + 30 * 24 * 60 * 60 * 1000); // +30 days
+
+  return {
+    signups: {
+      opens: formatDate(signupOpens),
+      closes: formatDate(votingOpens),
+    },
+    voting: {
+      opens: formatDate(votingOpens),
+      closes: formatDate(coveringBegins),
+    },
+    covering: {
+      opens: formatDate(coveringBegins),
+      closes: formatDate(coversDue),
+    },
+    celebration: {
+      opens: formatDate(coversDue),
+      closes: formatDate(listeningParty),
+    },
+  };
+}
+
+/**
+ * Create a mock round with sensible defaults
+ */
+export function createMockRound(overrides: Partial<MockRound> = {}): MockRound {
+  const now = new Date();
+  const baseDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000); // 7 days ago
+
+  return {
+    roundId: overrides.roundId ?? 1,
+    slug: overrides.slug ?? 'round-1',
+    phase: overrides.phase ?? 'covering',
+    song: overrides.song ?? { title: 'Test Song', artist: 'Test Artist' },
+    dateLabels: overrides.dateLabels ?? createDateLabels(baseDate),
+    hasRoundStarted: overrides.hasRoundStarted ?? true,
+    areSubmissionsOpen: overrides.areSubmissionsOpen ?? true,
+    isVotingOpen: overrides.isVotingOpen ?? false,
+    voteOptions: overrides.voteOptions ?? [],
+    submissions: overrides.submissions ?? [],
+    playlistUrl: overrides.playlistUrl,
+    signups: overrides.signups ?? [],
+    signupCount: overrides.signupCount ?? overrides.signups?.length ?? 0,
+    submissionCount: overrides.submissionCount ?? overrides.submissions?.length ?? 0,
+    signupOpens: overrides.signupOpens ?? baseDate,
+    votingOpens: overrides.votingOpens ?? new Date(baseDate.getTime() + 7 * 24 * 60 * 60 * 1000),
+    coveringBegins:
+      overrides.coveringBegins ?? new Date(baseDate.getTime() + 14 * 24 * 60 * 60 * 1000),
+    coversDue: overrides.coversDue ?? new Date(baseDate.getTime() + 28 * 24 * 60 * 60 * 1000),
+    listeningParty:
+      overrides.listeningParty ?? new Date(baseDate.getTime() + 30 * 24 * 60 * 60 * 1000),
+    votingEnabled: overrides.votingEnabled ?? true,
+  };
+}
+
+/**
+ * Pre-defined mock rounds for common test scenarios
+ */
+export const mockRounds = {
+  /**
+   * Round in signups phase
+   */
+  signupsPhase: createMockRound({
+    roundId: 10,
+    slug: 'round-10-signups',
+    phase: 'signups',
+    hasRoundStarted: true,
+    areSubmissionsOpen: false,
+    isVotingOpen: false,
+    voteOptions: [
+      { roundId: 10, songId: 1, song: { title: 'Song Option 1', artist: 'Artist 1' } },
+      { roundId: 10, songId: 2, song: { title: 'Song Option 2', artist: 'Artist 2' } },
+      { roundId: 10, songId: 3, song: { title: 'Song Option 3', artist: 'Artist 3' } },
+    ],
+  }),
+
+  /**
+   * Round in voting phase
+   */
+  votingPhase: createMockRound({
+    roundId: 11,
+    slug: 'round-11-voting',
+    phase: 'voting',
+    hasRoundStarted: true,
+    areSubmissionsOpen: false,
+    isVotingOpen: true,
+    voteOptions: [
+      { roundId: 11, songId: 4, song: { title: 'Vote Song 1', artist: 'Vote Artist 1' } },
+      { roundId: 11, songId: 5, song: { title: 'Vote Song 2', artist: 'Vote Artist 2' } },
+    ],
+    signups: [
+      {
+        id: 1,
+        userId: '11111111-1111-1111-1111-111111111111',
+        username: 'testuser1',
+        roundId: 11,
+        createdAt: new Date(),
+      },
+    ],
+  }),
+
+  /**
+   * Round in covering phase
+   */
+  coveringPhase: createMockRound({
+    roundId: 12,
+    slug: 'round-12-covering',
+    phase: 'covering',
+    song: { title: 'Cover This Song', artist: 'Famous Artist' },
+    hasRoundStarted: true,
+    areSubmissionsOpen: true,
+    isVotingOpen: false,
+    signups: [
+      {
+        id: 2,
+        userId: '11111111-1111-1111-1111-111111111111',
+        username: 'regularuser',
+        publicDisplayName: 'Regular User',
+        roundId: 12,
+        createdAt: new Date(),
+      },
+    ],
+    signupCount: 1,
+  }),
+
+  /**
+   * Round in celebration phase with submissions
+   */
+  celebrationPhase: createMockRound({
+    roundId: 13,
+    slug: 'round-13-celebration',
+    phase: 'celebration',
+    song: { title: 'Celebrated Song', artist: 'Great Artist' },
+    hasRoundStarted: true,
+    areSubmissionsOpen: false,
+    isVotingOpen: false,
+    playlistUrl: 'https://soundcloud.com/example/playlist',
+    submissions: [
+      {
+        roundId: 13,
+        username: 'regularuser',
+        publicDisplayName: 'Regular User',
+        userId: '11111111-1111-1111-1111-111111111111',
+        createdAt: new Date(),
+        audioFileUrl: 'https://example.com/audio1.mp3',
+        audioDuration: 180000,
+      },
+      {
+        roundId: 13,
+        username: 'anotheruser',
+        publicDisplayName: 'Another User',
+        userId: '66666666-6666-6666-6666-666666666666',
+        createdAt: new Date(),
+        audioFileUrl: 'https://example.com/audio2.mp3',
+        audioDuration: 210000,
+      },
+    ],
+    submissionCount: 2,
+    signupCount: 2,
+  }),
+
+  /**
+   * Round that hasn't started yet
+   */
+  notStarted: createMockRound({
+    roundId: 14,
+    slug: 'round-14-future',
+    phase: 'signups',
+    hasRoundStarted: false,
+    areSubmissionsOpen: false,
+    isVotingOpen: false,
+  }),
+};
+
+export type MockRoundKey = keyof typeof mockRounds;

--- a/apps/web/playwright/mocks/auth/session.ts
+++ b/apps/web/playwright/mocks/auth/session.ts
@@ -1,0 +1,139 @@
+/**
+ * Mock Supabase session factory for integration tests
+ *
+ * Creates valid-looking Supabase sessions for cookie injection
+ */
+
+import { MockUser } from './users';
+
+export interface MockSession {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  expires_at: number;
+  token_type: 'bearer';
+  user: MockUser;
+}
+
+/**
+ * Get the Supabase project reference from the URL
+ * Used to construct the correct cookie names
+ */
+export function getSupabaseProjectRef(): string {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://test.supabase.co';
+  // Extract project ref from URL like https://abcdefgh.supabase.co
+  const match = url.match(/https:\/\/([^.]+)\.supabase\.co/);
+  return match?.[1] || 'test';
+}
+
+/**
+ * Create a mock JWT-like access token
+ * Note: This is not a real JWT, just a base64-encoded mock for testing
+ */
+function createMockAccessToken(user: MockUser): string {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const payload = {
+    aud: 'authenticated',
+    exp: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
+    iat: Math.floor(Date.now() / 1000),
+    iss: process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://test.supabase.co/auth/v1',
+    sub: user.id,
+    email: user.email,
+    phone: '',
+    app_metadata: user.app_metadata,
+    user_metadata: user.user_metadata,
+    role: 'authenticated',
+    aal: 'aal1',
+    amr: [{ method: 'password', timestamp: Math.floor(Date.now() / 1000) }],
+    session_id: crypto.randomUUID(),
+  };
+
+  // Create a mock JWT (header.payload.signature)
+  const base64Header = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const base64Payload = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  // In real JWTs, the signature is cryptographically generated
+  // For mocking, we just create a deterministic fake signature
+  const fakeSignature = Buffer.from(`mock_sig_${user.id}`).toString('base64url');
+
+  return `${base64Header}.${base64Payload}.${fakeSignature}`;
+}
+
+/**
+ * Create a mock refresh token
+ */
+function createMockRefreshToken(): string {
+  return `mock_refresh_${crypto.randomUUID()}`;
+}
+
+/**
+ * Create a mock Supabase session for a user
+ */
+export function createMockSession(user: MockUser): MockSession {
+  const expiresIn = 3600; // 1 hour
+  const expiresAt = Math.floor(Date.now() / 1000) + expiresIn;
+
+  return {
+    access_token: createMockAccessToken(user),
+    refresh_token: createMockRefreshToken(),
+    expires_in: expiresIn,
+    expires_at: expiresAt,
+    token_type: 'bearer',
+    user,
+  };
+}
+
+/**
+ * Get the Supabase auth cookie name
+ * Supabase SSR stores auth in a cookie named: sb-<project-ref>-auth-token
+ */
+export function getAuthCookieName(): string {
+  const projectRef = getSupabaseProjectRef();
+  return `sb-${projectRef}-auth-token`;
+}
+
+/**
+ * Encode a session into the format Supabase SSR expects in cookies
+ * Supabase stores the session as base64-encoded JSON
+ */
+export function encodeSessionForCookie(session: MockSession): string {
+  return Buffer.from(JSON.stringify(session)).toString('base64');
+}
+
+/**
+ * Get cookies needed to authenticate as a user
+ * Returns an array of cookie objects ready for Playwright's context.addCookies()
+ */
+export function getSupabaseCookies(
+  user: MockUser,
+  domain = 'localhost'
+): Array<{
+  name: string;
+  value: string;
+  domain: string;
+  path: string;
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: 'Strict' | 'Lax' | 'None';
+}> {
+  const session = createMockSession(user);
+  const cookieName = getAuthCookieName();
+
+  // Supabase SSR may split large cookies into chunks
+  // For our mock sessions, a single cookie should suffice
+  // The format is: sb-<ref>-auth-token.0, sb-<ref>-auth-token.1, etc.
+  // But for simplicity, we'll use a single cookie
+
+  const sessionValue = encodeSessionForCookie(session);
+
+  return [
+    {
+      name: `${cookieName}.0`,
+      value: `base64-${sessionValue}`,
+      domain,
+      path: '/',
+      httpOnly: true,
+      secure: false, // Set to false for localhost
+      sameSite: 'Lax' as const,
+    },
+  ];
+}

--- a/apps/web/playwright/mocks/auth/users.ts
+++ b/apps/web/playwright/mocks/auth/users.ts
@@ -1,0 +1,121 @@
+/**
+ * Mock user data for integration tests
+ *
+ * These users match the Supabase User type and our internal user schema
+ */
+
+export interface MockUser {
+  id: string;
+  email: string;
+  username: string;
+  publicDisplayName?: string | null;
+  adminLevel?: number | null;
+  profilePictureUrl?: string | null;
+  createdAt: Date;
+  // Supabase-specific fields
+  app_metadata: Record<string, unknown>;
+  user_metadata: Record<string, unknown>;
+  aud: string;
+  confirmed_at?: string;
+  email_confirmed_at?: string;
+  phone?: string;
+  last_sign_in_at?: string;
+  role?: string;
+}
+
+function createMockUser(overrides: Partial<MockUser> = {}): MockUser {
+  const id = overrides.id || crypto.randomUUID();
+  const email = overrides.email || `test-${id.slice(0, 8)}@example.com`;
+  const username = overrides.username || `testuser_${id.slice(0, 8)}`;
+  const now = new Date().toISOString();
+
+  return {
+    id,
+    email,
+    username,
+    publicDisplayName: overrides.publicDisplayName ?? null,
+    adminLevel: overrides.adminLevel ?? null,
+    profilePictureUrl: overrides.profilePictureUrl ?? null,
+    createdAt: overrides.createdAt || new Date(),
+    app_metadata: {
+      provider: 'email',
+      providers: ['email'],
+      ...overrides.app_metadata,
+    },
+    user_metadata: {
+      username,
+      ...overrides.user_metadata,
+    },
+    aud: 'authenticated',
+    confirmed_at: now,
+    email_confirmed_at: now,
+    last_sign_in_at: now,
+    role: 'authenticated',
+    ...overrides,
+  };
+}
+
+/**
+ * Pre-defined mock users for common test scenarios
+ */
+export const mockUsers = {
+  /**
+   * Regular authenticated user
+   */
+  regular: createMockUser({
+    id: '11111111-1111-1111-1111-111111111111',
+    email: 'regular@example.com',
+    username: 'regularuser',
+    publicDisplayName: 'Regular User',
+  }),
+
+  /**
+   * Admin user with elevated privileges
+   */
+  admin: createMockUser({
+    id: '22222222-2222-2222-2222-222222222222',
+    email: 'admin@example.com',
+    username: 'adminuser',
+    publicDisplayName: 'Admin User',
+    adminLevel: 1,
+  }),
+
+  /**
+   * Super admin with highest privileges
+   */
+  superAdmin: createMockUser({
+    id: '33333333-3333-3333-3333-333333333333',
+    email: process.env.NEXT_PUBLIC_ADMIN_EMAIL || 'superadmin@example.com',
+    username: 'superadmin',
+    publicDisplayName: 'Super Admin',
+    adminLevel: 2,
+  }),
+
+  /**
+   * New user (recently created, minimal data)
+   */
+  newUser: createMockUser({
+    id: '44444444-4444-4444-4444-444444444444',
+    email: 'newuser@example.com',
+    username: 'newuser',
+    createdAt: new Date(),
+  }),
+
+  /**
+   * User with profile picture
+   */
+  withAvatar: createMockUser({
+    id: '55555555-5555-5555-5555-555555555555',
+    email: 'avatar@example.com',
+    username: 'avataruser',
+    publicDisplayName: 'Avatar User',
+    profilePictureUrl: 'https://example.com/avatar.jpg',
+  }),
+};
+
+export { createMockUser };
+
+/**
+ * Type for mock user keys
+ */
+export type MockUserKey = keyof typeof mockUsers;

--- a/apps/web/playwright/mocks/index.ts
+++ b/apps/web/playwright/mocks/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Central export for all mock data
+ */
+
+// Auth mocks
+export * from './auth/users';
+export * from './auth/session';
+
+// API mocks
+export * from './api/rounds';
+export * from './api/notifications';

--- a/apps/web/playwright/tests/api/round-info.spec.ts
+++ b/apps/web/playwright/tests/api/round-info.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * API mocking integration tests
+ *
+ * Validates that API mocking fixtures work correctly.
+ * These are infrastructure tests - actual API behavior tests
+ * will be added when mock data is implemented.
+ */
+
+import { test, expect } from '../../fixtures';
+
+test.describe('API Mocking Infrastructure', () => {
+  test.beforeEach(async ({ loginAs }) => {
+    await loginAs('regular');
+  });
+
+  test('mockApi fixtures intercept requests correctly', async ({ page, mockApi }) => {
+    await mockApi.roundInfo({ roundId: 12, slug: 'round-12', phase: 'covering' });
+    await mockApi.notifications([]);
+    await mockApi.unreadNotificationCount(0);
+
+    await page.goto('/dashboard');
+    await expect(page.locator('body')).toBeVisible();
+  });
+
+  test('failWith fixture can simulate API errors', async ({ page, mockApi }) => {
+    await mockApi.failWith('**/api/round-info**', 500, 'Database error');
+    await mockApi.notifications([]);
+    await mockApi.unreadNotificationCount(0);
+
+    await page.goto('/dashboard');
+    // Page should handle error gracefully without crashing
+    await expect(page.locator('body')).toBeVisible();
+  });
+});

--- a/apps/web/playwright/tests/auth/protected-routes.spec.ts
+++ b/apps/web/playwright/tests/auth/protected-routes.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Protected routes integration tests
+ *
+ * Tests authentication redirects and access control.
+ */
+
+import { test, expect } from '../../fixtures';
+
+test.describe('Protected Routes - Unauthenticated', () => {
+  const protectedRoutes = [
+    '/dashboard',
+    '/submit',
+    '/voting',
+    '/projects/cover/dashboard',
+    '/projects/cover/voting',
+    '/projects/cover/submit',
+  ];
+
+  for (const route of protectedRoutes) {
+    test(`redirects ${route} to /login`, async ({ page }) => {
+      await page.goto(route);
+      await expect(page).toHaveURL(/\/login/);
+    });
+  }
+
+  test('preserves redirect URL in query params', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/login.*redirectUrl/);
+  });
+});
+
+test.describe('Protected Routes - Authenticated', () => {
+  test.beforeEach(async ({ loginAs }) => {
+    await loginAs('regular');
+  });
+
+  test('allows access to /dashboard', async ({ page, mockApi }) => {
+    await mockApi.roundInfo({ phase: 'covering' });
+    await mockApi.notifications([]);
+    await mockApi.unreadNotificationCount(0);
+
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL('/dashboard');
+  });
+
+  test('allows access to project dashboard', async ({ page, mockApi }) => {
+    await mockApi.roundInfo({ phase: 'covering' });
+    await mockApi.notifications([]);
+    await mockApi.unreadNotificationCount(0);
+
+    await page.goto('/projects/cover/dashboard');
+    await expect(page).toHaveURL(/\/projects\/cover/);
+  });
+});
+
+test.describe('Public Routes - Authenticated', () => {
+  test.beforeEach(async ({ loginAs }) => {
+    await loginAs('regular');
+  });
+
+  test('redirects /login to /dashboard when authenticated', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page).toHaveURL('/dashboard');
+  });
+
+  test('redirects /sign-up when authenticated', async ({ page }) => {
+    await page.goto('/sign-up');
+    await expect(page).toHaveURL(/\/projects\/.*\/sign-up|\/dashboard/);
+  });
+});
+
+test.describe('Admin Routes', () => {
+  test('redirects non-admin from /admin', async ({ page, loginAs }) => {
+    await loginAs('regular');
+    await page.goto('/admin');
+    await expect(page).not.toHaveURL('/admin');
+  });
+
+  test('allows admin access to /admin', async ({ page, loginAs }) => {
+    await loginAs('superAdmin');
+    await page.goto('/admin');
+    // Admin should have access (exact behavior depends on env setup)
+    expect(page.url()).toBeTruthy();
+  });
+});
+
+test.describe('Auth State Transitions', () => {
+  test('logout removes access to protected routes', async ({
+    page,
+    loginAs,
+    logout,
+    mockApi,
+  }) => {
+    await loginAs('regular');
+    await mockApi.roundInfo({ phase: 'covering' });
+    await mockApi.notifications([]);
+    await mockApi.unreadNotificationCount(0);
+
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL('/dashboard');
+
+    await logout();
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test('login state persists across navigation', async ({
+    page,
+    loginAs,
+    isAuthenticated,
+    mockApi,
+  }) => {
+    await loginAs('regular');
+    await mockApi.roundInfo({ phase: 'covering' });
+    await mockApi.notifications([]);
+    await mockApi.unreadNotificationCount(0);
+
+    await page.goto('/dashboard');
+    expect(await isAuthenticated()).toBe(true);
+
+    await page.goto('/');
+    expect(await isAuthenticated()).toBe(true);
+    await expect(page).toHaveURL('/dashboard');
+  });
+});

--- a/apps/web/playwright/tests/pages/dashboard.spec.ts
+++ b/apps/web/playwright/tests/pages/dashboard.spec.ts
@@ -1,0 +1,22 @@
+/**
+ * Dashboard page integration tests
+ *
+ * Tests the authenticated dashboard page rendering.
+ * Note: In test mode, database returns empty arrays, so users see "No Projects" state.
+ */
+
+import { test, expect } from '../../fixtures';
+
+test.describe('Dashboard Page', () => {
+  test('renders empty state for authenticated user with no projects', async ({
+    page,
+    loginAs,
+  }) => {
+    await loginAs('regular');
+    await page.goto('/dashboard');
+
+    await expect(page).toHaveURL('/dashboard');
+    await expect(page.getByRole('heading', { name: /No Projects/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Browse Projects/i })).toBeVisible();
+  });
+});

--- a/apps/web/playwright/tests/pages/home.spec.ts
+++ b/apps/web/playwright/tests/pages/home.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Homepage integration tests
+ *
+ * Tests the public homepage rendering and navigation behavior.
+ * Note: In test mode, database queries return empty arrays by default.
+ */
+
+import { test, expect } from '../../fixtures';
+
+test.describe('Homepage', () => {
+  test('renders for unauthenticated users', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.locator('body')).toBeVisible();
+    await expect(page).toHaveURL('/');
+
+    // Should have navigation links
+    const navLinks = page.locator('nav a, header a');
+    const linkCount = await navLinks.count();
+    expect(linkCount).toBeGreaterThan(0);
+  });
+
+  test('redirects authenticated users to dashboard', async ({ page, loginAs }) => {
+    await loginAs('regular');
+    await page.goto('/');
+    await expect(page).toHaveURL('/dashboard');
+  });
+
+  test('login link navigates to login page', async ({ page }) => {
+    await page.goto('/');
+
+    const loginLink = page.locator(
+      'a[href*="/login"], button:has-text("Login"), a:has-text("Login"), a:has-text("Sign In")'
+    );
+
+    if ((await loginLink.count()) > 0) {
+      await loginLink.first().click();
+      await expect(page).toHaveURL(/\/login/);
+    }
+  });
+});

--- a/apps/web/playwright/utils/wait-helpers.ts
+++ b/apps/web/playwright/utils/wait-helpers.ts
@@ -1,0 +1,101 @@
+/**
+ * Custom wait utilities for Playwright tests
+ */
+
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Wait for the page to be fully loaded (no network activity)
+ */
+export async function waitForPageLoad(page: Page, timeout = 10000): Promise<void> {
+  await page.waitForLoadState('networkidle', { timeout });
+}
+
+/**
+ * Wait for Next.js hydration to complete
+ * Checks for absence of data-loading attributes or presence of loaded state
+ */
+export async function waitForHydration(page: Page, timeout = 10000): Promise<void> {
+  // Wait for the main content to be visible
+  await page.waitForLoadState('domcontentloaded', { timeout });
+
+  // Give React time to hydrate
+  await page.waitForTimeout(100);
+
+  // Wait for any loading skeletons to disappear
+  const skeletons = page.locator('[data-testid="loading-skeleton"], .skeleton');
+  const skeletonCount = await skeletons.count();
+  if (skeletonCount > 0) {
+    await expect(skeletons.first()).not.toBeVisible({ timeout });
+  }
+}
+
+/**
+ * Wait for a specific API response
+ * Returns the Playwright Response object (not the native Response)
+ */
+export async function waitForApiResponse(
+  page: Page,
+  urlPattern: string | RegExp,
+  timeout = 10000
+): Promise<import('@playwright/test').Response> {
+  const response = await page.waitForResponse(
+    (response) => {
+      const url = response.url();
+      if (typeof urlPattern === 'string') {
+        return url.includes(urlPattern);
+      }
+      return urlPattern.test(url);
+    },
+    { timeout }
+  );
+  return response;
+}
+
+/**
+ * Wait for navigation to complete
+ */
+export async function waitForNavigation(
+  page: Page,
+  urlPattern: string | RegExp,
+  timeout = 10000
+): Promise<void> {
+  await page.waitForURL(urlPattern, { timeout });
+}
+
+/**
+ * Wait for an element to be stable (not animating/transitioning)
+ */
+export async function waitForElementStable(
+  page: Page,
+  selector: string,
+  timeout = 5000
+): Promise<void> {
+  const element = page.locator(selector);
+  await element.waitFor({ state: 'visible', timeout });
+
+  // Wait for any CSS transitions to complete
+  await page.waitForTimeout(300);
+}
+
+/**
+ * Retry an action until it succeeds or times out
+ */
+export async function retryUntil<T>(
+  action: () => Promise<T>,
+  options: { timeout?: number; interval?: number } = {}
+): Promise<T> {
+  const { timeout = 10000, interval = 100 } = options;
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeout) {
+    try {
+      return await action();
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+  }
+
+  // One final try that will throw if it fails
+  return action();
+}

--- a/bun.lock
+++ b/bun.lock
@@ -98,6 +98,8 @@
         "zod": "^3.24.1",
       },
       "devDependencies": {
+        "@playwright/experimental-ct-react": "^1.58.0",
+        "@playwright/test": "^1.58.0",
         "@tailwindcss/postcss": "^4.0.14",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -112,6 +114,7 @@
         "eslint": "8.26.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "playwright": "^1.58.0",
         "postcss": "8.4.35",
         "tailwindcss": "^4.1.17",
         "ts-node": "^10.9.2",
@@ -789,6 +792,10 @@
 
     "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ=="],
 
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
     "@babel/runtime": ["@babel/runtime@7.28.4", "", {}, "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ=="],
 
     "@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
@@ -818,6 +825,8 @@
     "@date-fns/tz": ["@date-fns/tz@1.4.1", "", {}, "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.3.15", "", {}, "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.6.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-zq/ay+9fNIJJtJiZxdTnXS20PllcYMX3OE23ESc4HK/bdYu3cOWYVhsOhVnXALfU/uqJIxn5NBPd9z4v+SfoSg=="],
 
@@ -1231,6 +1240,12 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
+    "@playwright/experimental-ct-core": ["@playwright/experimental-ct-core@1.58.0", "", { "dependencies": { "playwright": "1.58.0", "playwright-core": "1.58.0", "vite": "^6.4.1" } }, "sha512-YZsjApZmRE78Kp2E6OtAvFFVheUyZDfrlZMf+lfnSshmYHrrJUy3bhdCe7EPCWsE12XfCVVAv6G0btiyAx8d0w=="],
+
+    "@playwright/experimental-ct-react": ["@playwright/experimental-ct-react@1.58.0", "", { "dependencies": { "@playwright/experimental-ct-core": "1.58.0", "@vitejs/plugin-react": "^4.2.1" }, "bin": { "playwright": "cli.js" } }, "sha512-hm3Vddy1zNrTFfh2qwjuKvz8lY9oJm2iQkSITSMat4tztK5KxfwJrRyLGeZNCuzAy3bCWGk80Rb0ZfQ3Vitw+A=="],
+
+    "@playwright/test": ["@playwright/test@1.58.0", "", { "dependencies": { "playwright": "1.58.0" }, "bin": { "playwright": "cli.js" } }, "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg=="],
+
     "@posthog/core": ["@posthog/core@1.3.0", "", {}, "sha512-hxLL8kZNHH098geedcxCz8y6xojkNYbmJEW+1vFXsmPcExyCXIUUJ/34X6xa9GcprKxd0Wsx3vfJQLQX4iVPhw=="],
 
     "@prisma/instrumentation": ["@prisma/instrumentation@5.22.0", "", { "dependencies": { "@opentelemetry/api": "^1.8", "@opentelemetry/instrumentation": "^0.49 || ^0.50 || ^0.51 || ^0.52.0 || ^0.53.0", "@opentelemetry/sdk-trace-base": "^1.22" } }, "sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q=="],
@@ -1370,6 +1385,8 @@
     "@react-email/tailwind": ["@react-email/tailwind@1.2.2", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-heO9Khaqxm6Ulm6p7HQ9h01oiiLRrZuuEQuYds/O7Iyp3c58sMVHZGIxiRXO/kSs857NZQycpjewEVKF3jhNTw=="],
 
     "@react-email/text": ["@react-email/text@0.0.10", "", { "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-wNAnxeEAiFs6N+SxS0y6wTJWfewEzUETuyS2aZmT00xk50VijwyFRuhm4sYSjusMyshevomFwz5jNISCxRsGWw=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@rollup/plugin-commonjs": ["@rollup/plugin-commonjs@28.0.1", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "commondir": "^1.0.1", "estree-walker": "^2.0.2", "fdir": "^6.2.0", "is-reference": "1.2.1", "magic-string": "^0.30.3", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^2.68.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA=="],
 
@@ -1916,6 +1933,8 @@
     "@vanilla-extract/private": ["@vanilla-extract/private@1.0.9", "", {}, "sha512-gT2jbfZuaaCLrAxwXbRgIhGhcXbRZCG3v4TTUnjw0EJ7ArdBRxkq4msNJkbuRkCgfIK5ATmprB5t9ljvLeFDEA=="],
 
     "@vanilla-extract/webpack-plugin": ["@vanilla-extract/webpack-plugin@2.3.22", "", { "dependencies": { "@vanilla-extract/integration": "^8.0.4", "debug": "^4.3.1", "loader-utils": "^2.0.0", "picocolors": "^1.0.0" }, "peerDependencies": { "webpack": "^4.30.0 || ^5.20.2" } }, "sha512-3Cx8DkbX3EeLHGbD049jjj6/bWB0VK4YFfWWsf8VXBI8dgf5SvEef1VfET22IOcT9GzLl8MqfsLr/XSo9iv67Q=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
     "@vitest/expect": ["@vitest/expect@2.0.5", "", { "dependencies": { "@vitest/spy": "2.0.5", "@vitest/utils": "2.0.5", "chai": "^5.1.1", "tinyrainbow": "^1.2.0" } }, "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA=="],
 
@@ -3307,6 +3326,10 @@
 
     "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
+    "playwright": ["playwright@1.58.0", "", { "dependencies": { "playwright-core": "1.58.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ=="],
+
+    "playwright-core": ["playwright-core@1.58.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw=="],
+
     "polished": ["polished@4.3.1", "", { "dependencies": { "@babel/runtime": "^7.17.8" } }, "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
@@ -3404,6 +3427,8 @@
     "react-mentions": ["react-mentions@4.4.10", "", { "dependencies": { "@babel/runtime": "7.4.5", "invariant": "^2.2.4", "prop-types": "^15.5.8", "substyle": "^9.1.0" }, "peerDependencies": { "react": ">=16.8.3", "react-dom": ">=16.8.3" } }, "sha512-JHiQlgF1oSZR7VYPjq32wy97z1w1oE4x10EuhKjPr4WUKhVzG1uFQhQjKqjQkbVqJrmahf+ldgBTv36NrkpKpA=="],
 
     "react-promise-suspense": ["react-promise-suspense@0.3.4", "", { "dependencies": { "fast-deep-equal": "^2.0.1" } }, "sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.1", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA=="],
 
@@ -4376,6 +4401,8 @@
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "posthog-node/@posthog/core": ["@posthog/core@1.3.1", "", {}, "sha512-sGKVHituJ8L/bJxVV4KamMFp+IBWAZyCiYunFawJZ4cc59PCtLnKFIMEV6kn7A4eZQcQ6EKV5Via4sF3Z7qMLQ=="],
 

--- a/packages/auth/src/middleware/testAuthBypass.ts
+++ b/packages/auth/src/middleware/testAuthBypass.ts
@@ -1,0 +1,78 @@
+/**
+ * Test Auth Bypass for Playwright Integration Tests
+ *
+ * This module provides a mechanism for Playwright tests to bypass Supabase
+ * authentication by using a special cookie. This is ONLY active when the
+ * PLAYWRIGHT_TEST_MODE environment variable is set to 'true'.
+ *
+ * Security Note: This bypass should NEVER be enabled in production.
+ * The env var check ensures it only works in test environments.
+ */
+
+import { type NextRequest } from 'next/server';
+
+/**
+ * Test user data structure for auth bypass
+ */
+export interface TestAuthUser {
+  id: string;
+  email: string;
+  username?: string;
+  adminLevel?: number;
+}
+
+/**
+ * Cookie name used for test authentication
+ */
+export const TEST_AUTH_COOKIE_NAME = '__playwright_test_auth';
+
+/**
+ * Parse test auth cookie for integration testing
+ * Cookie format: JSON with { id, email, username?, adminLevel? }
+ *
+ * @returns Parsed user data or null if invalid/missing
+ */
+export function parseTestAuthCookie(cookieValue: string | undefined): TestAuthUser | null {
+  if (!cookieValue) return null;
+  try {
+    const parsed = JSON.parse(cookieValue);
+    if (parsed.id && parsed.email) {
+      return {
+        id: parsed.id,
+        email: parsed.email,
+        username: parsed.username,
+        adminLevel: parsed.adminLevel,
+      };
+    }
+  } catch {
+    // Invalid JSON - return null
+  }
+  return null;
+}
+
+/**
+ * Check if test mode is enabled and extract test user from cookie
+ *
+ * This function checks for:
+ * 1. PLAYWRIGHT_TEST_MODE environment variable set to 'true'
+ * 2. Valid __playwright_test_auth cookie with user data
+ *
+ * @param request - The Next.js request object
+ * @returns Test user data if in test mode with valid cookie, null otherwise
+ */
+export function getTestAuthUser(request: NextRequest): TestAuthUser | null {
+  // Only allow test bypass when explicitly enabled
+  if (process.env.PLAYWRIGHT_TEST_MODE !== 'true') {
+    return null;
+  }
+
+  const testAuthCookie = request.cookies.get(TEST_AUTH_COOKIE_NAME)?.value;
+  return parseTestAuthCookie(testAuthCookie);
+}
+
+/**
+ * Check if a test user has admin privileges
+ */
+export function isTestUserAdmin(testUser: TestAuthUser): boolean {
+  return testUser.adminLevel !== undefined && testUser.adminLevel > 0;
+}

--- a/packages/auth/src/middleware/testAuthServer.ts
+++ b/packages/auth/src/middleware/testAuthServer.ts
@@ -1,0 +1,49 @@
+/**
+ * Server-Side Test Auth for Playwright Integration Tests
+ *
+ * This module provides test authentication bypass for Server Components.
+ * Unlike testAuthBypass.ts (which uses NextRequest for middleware),
+ * this uses next/headers to read cookies in server components.
+ *
+ * ONLY active when PLAYWRIGHT_TEST_MODE environment variable is 'true'.
+ *
+ * Security Note: This bypass should NEVER be enabled in production.
+ */
+
+import {
+  TEST_AUTH_COOKIE_NAME,
+  parseTestAuthCookie,
+  type TestAuthUser,
+} from './testAuthBypass';
+
+// Re-export for convenience
+export { TEST_AUTH_COOKIE_NAME, type TestAuthUser };
+
+/**
+ * Check if running in Playwright test mode
+ */
+export function isTestMode(): boolean {
+  return process.env.PLAYWRIGHT_TEST_MODE === 'true';
+}
+
+/**
+ * Get test user from cookies in Server Components
+ *
+ * Uses next/headers to read the test auth cookie.
+ * Returns null if not in test mode or no valid cookie.
+ */
+export async function getTestUserFromCookies(): Promise<TestAuthUser | null> {
+  if (!isTestMode()) {
+    return null;
+  }
+
+  try {
+    const { cookies } = await import('next/headers');
+    const cookieStore = await cookies();
+    const testAuthCookie = cookieStore.get(TEST_AUTH_COOKIE_NAME)?.value;
+    return parseTestAuthCookie(testAuthCookie);
+  } catch {
+    // Cookie reading failed (e.g., not in a server context)
+    return null;
+  }
+}

--- a/packages/data-access/package.json
+++ b/packages/data-access/package.json
@@ -22,21 +22,21 @@
     "clean": "rm -rf .turbo node_modules"
   },
   "dependencies": {
+    "@date-fns/tz": "^1.2.0",
+    "@eptss/logger": "workspace:*",
     "@eptss/routing": "workspace:*",
     "@eptss/shared": "workspace:*",
-    "@eptss/logger": "workspace:*",
     "@libsql/client": "^0.14.0",
     "@supabase/ssr": "^0.5.1",
     "@supabase/supabase-js": "^2.45.4",
+    "date-fns": "^2.30.0",
     "drizzle-orm": "^0.38.4",
     "drizzle-zod": "^0.6.1",
-    "postgres": "^3.4.5",
-    "zod": "^3.24.1",
-    "date-fns": "^2.30.0",
-    "@date-fns/tz": "^1.2.0",
     "next": "16.0.7",
+    "postgres": "^3.4.5",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/node": "18.11.3",

--- a/packages/data-access/src/db/index.ts
+++ b/packages/data-access/src/db/index.ts
@@ -2,6 +2,63 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema";
 
+// Check if we're in Playwright test mode
+const isPlaywrightTestMode = process.env.PLAYWRIGHT_TEST_MODE === "true";
+
+// Type for our database instance
+type DatabaseInstance = ReturnType<typeof drizzle<typeof schema>>;
+
+/**
+ * Create a mock database that returns empty results for all queries.
+ * This allows tests to run without a real database connection.
+ * Tests can use the mockDb fixture to set up specific data via the test API.
+ */
+const createMockDb = (): DatabaseInstance => {
+  // Create a chainable mock that returns empty results
+  const createChainableMock = (): any => {
+    const mock: any = {
+      // Always return empty array for queries
+      then: (resolve: (value: any[]) => void) => {
+        resolve([]);
+        return Promise.resolve([]);
+      },
+    };
+
+    // Make all method calls return the mock itself for chaining
+    return new Proxy(mock, {
+      get(target, prop) {
+        if (prop === 'then') {
+          return target.then;
+        }
+        // For any other property, return a function that returns this mock
+        return (...args: any[]) => createChainableMock();
+      },
+    });
+  };
+
+  // Create the main db mock
+  const mockDb = new Proxy({} as DatabaseInstance, {
+    get(target, prop) {
+      // For select/insert/update/delete, return chainable mock
+      if (['select', 'insert', 'update', 'delete', 'query'].includes(prop as string)) {
+        return (...args: any[]) => createChainableMock();
+      }
+      // For execute (raw SQL), return empty array
+      if (prop === 'execute') {
+        return async () => [];
+      }
+      // For transaction, execute the callback with the mock
+      if (prop === 'transaction') {
+        return async (callback: (tx: any) => Promise<any>) => callback(mockDb);
+      }
+      // Return undefined for other properties
+      return undefined;
+    },
+  });
+
+  return mockDb;
+};
+
 // Singleton pattern to prevent connection leaks in development with Next.js hot reloading
 const createPostgresConnection = () => {
   // Connection pooling configuration with strict limits
@@ -25,20 +82,29 @@ const globalForPg = global as unknown as {
   pg: ReturnType<typeof postgres> | undefined;
 };
 
-// In production, create a new connection for each server instance
-// In development, reuse the connection to prevent leaks during hot reloading
-const client = 
-  (process.env.NODE_ENV === "production" || !globalForPg.pg)
-    ? createPostgresConnection()
-    : globalForPg.pg;
+// Initialize database based on mode
+let db: DatabaseInstance;
 
-// Save the client reference in development
-if (process.env.NODE_ENV !== "production" && !globalForPg.pg) {
-  globalForPg.pg = client;
+if (isPlaywrightTestMode) {
+  // In test mode, use mock database that returns empty results
+  // Tests can configure specific responses via the test API
+  db = createMockDb();
+} else {
+  // In production/development, use real Postgres
+  const client =
+    (process.env.NODE_ENV === "production" || !globalForPg.pg)
+      ? createPostgresConnection()
+      : globalForPg.pg;
+
+  // Save the client reference in development
+  if (process.env.NODE_ENV !== "production" && !globalForPg.pg) {
+    globalForPg.pg = client;
+  }
+
+  db = drizzle(client, { schema });
 }
 
-// Create drizzle instance with schema
-export const db = drizzle(client, { schema });
+export { db };
 
 // Export schema tables for special use cases (like @eptss/project-config)
 export { projects } from "./schema";
@@ -46,15 +112,17 @@ export { projects } from "./schema";
 // Export commonly used operators
 export { eq } from "drizzle-orm";
 
-// Explicitly handle process termination to close connections
-if (process.env.NODE_ENV !== "test") {
+// Explicitly handle process termination to close connections (only for real Postgres)
+if (!isPlaywrightTestMode && process.env.NODE_ENV !== "test") {
   // Handle various termination signals
   const signals = ["SIGTERM", "SIGINT", "beforeExit", "exit"];
-  
+
   signals.forEach((signal) => {
     process.on(signal, () => {
-      console.log(`Closing Postgres connections due to ${signal}`);
-      client.end({ timeout: 5 }).catch(console.error);
+      if (globalForPg.pg) {
+        console.log(`Closing Postgres connections due to ${signal}`);
+        globalForPg.pg.end({ timeout: 5 }).catch(console.error);
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
- Set up Playwright with mock database that returns empty arrays in test mode
- Add test auth bypass via cookie for authenticated route testing
- Create fixtures for auth (`loginAs`, `logout`) and API mocking (`mockApi`)
- Add 21 integration tests covering homepage, dashboard, protected routes, and API mocking

## Key Implementation Details
- **Mock database at connection level** (`packages/data-access/src/db/index.ts`): When `PLAYWRIGHT_TEST_MODE=true`, database queries return empty arrays without modifying service code
- **Test auth bypass** (`packages/auth/src/middleware/testAuthBypass.ts`): Cookie-based authentication for tests
- **Playwright fixtures** (`apps/web/playwright/fixtures/`): Reusable auth and API mocking helpers

## Test coverage
- Homepage rendering and navigation
- Dashboard empty state
- Protected route redirects for unauthenticated users  
- Auth state transitions (login/logout)
- API mocking infrastructure validation

## How to run
```bash
cd apps/web
PLAYWRIGHT_TEST_MODE=true npx playwright test
```

## Test plan
- [x] All 21 tests pass locally
- [ ] Verify tests work in CI environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)