### PR TITLE
fix dates: pass UTC ISO, format on client in user's local TZ

### DIFF
--- a/apps/web/app/admin/rounds/[slug]/page.tsx
+++ b/apps/web/app/admin/rounds/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { DataTable } from "@eptss/ui";
+import { DataTable, FormattedDate } from "@eptss/ui";
 import { roundProvider, votesProvider, COVER_PROJECT_ID } from "@eptss/core";
 import { routes } from "@eptss/routing";
 import { ArrowLeft } from "lucide-react";
@@ -17,8 +17,8 @@ async function RoundDetailContent({ slug, projectId }: { slug: string; projectId
 
   const datesArray = Object.entries(dateLabels)?.map(([key, { opens, closes }]) => ({
     phase: key,
-    opens: new Date(opens).toLocaleString(),
-    closes: new Date(closes).toLocaleString()
+    opens: <FormattedDate iso={opens} format="full" />,
+    closes: <FormattedDate iso={closes} format="full" />,
   }));
   const dateHeaders = [
     { key: 'phase', label: 'Phase', sortable: true },
@@ -44,7 +44,7 @@ async function RoundDetailContent({ slug, projectId }: { slug: string; projectId
     title: vote.title || '',
     artist: vote.artist || '',
     vote: vote.vote,
-    submittedAt: vote.createdAt ? new Date(vote.createdAt).toLocaleString() : ''
+    submittedAt: vote.createdAt ? <FormattedDate iso={vote.createdAt} format="full" /> : ''
   }));
 
   const individualVotesHeaders = [

--- a/apps/web/app/dashboard/ActionPanelWrapper.tsx
+++ b/apps/web/app/dashboard/ActionPanelWrapper.tsx
@@ -18,7 +18,7 @@ export interface ActionPanelWrapperData extends ActionPanelData {
   phaseName?: string;
   phaseMessage?: string;
   timeRemaining?: string;
-  dueDate?: string;
+  dueDateIso?: string;
   urgencyLevel?: 'normal' | 'warning' | 'urgent';
   hasSignedUp?: boolean;
   hasSubmitted?: boolean;
@@ -84,7 +84,7 @@ export async function ActionPanelWrapper({ data, config }: PanelProps<ActionPane
     phaseName = 'Current Phase',
     phaseMessage,
     timeRemaining,
-    dueDate,
+    dueDateIso,
     urgencyLevel = 'normal',
     hasSignedUp = false,
     hasSubmitted = false,

--- a/apps/web/app/dashboard/CountdownBarWrapper.tsx
+++ b/apps/web/app/dashboard/CountdownBarWrapper.tsx
@@ -1,10 +1,10 @@
 import type { PanelProps } from "@eptss/dashboard";
 
-import { Text } from "@eptss/ui";
+import { FormattedDate, Text } from "@eptss/ui";
 interface CountdownBarData {
   phase: 'signups' | 'voting' | 'covering' | 'celebration';
   timeRemaining?: string;
-  dueDate?: string;
+  dueDateIso?: string;
   urgencyLevel?: 'normal' | 'warning' | 'urgent';
   hasSignedUp?: boolean;
   hasVoted?: boolean;
@@ -29,7 +29,7 @@ export function CountdownBarWrapper({ data }: PanelProps<CountdownBarData>) {
     return null;
   }
 
-  const { phase, timeRemaining, dueDate, urgencyLevel = 'normal', hasSignedUp, hasVoted, hasSubmitted, terminology } = data;
+  const { phase, timeRemaining, dueDateIso, urgencyLevel = 'normal', hasSignedUp, hasVoted, hasSubmitted, terminology } = data;
 
   const urgencyStyles = {
     normal: 'text-[var(--color-accent-primary)]',
@@ -72,10 +72,12 @@ export function CountdownBarWrapper({ data }: PanelProps<CountdownBarData>) {
           <span className={`font-bold ${urgencyStyles[urgencyLevel]}`}>
             {timeRemaining || 'Starting soon'}
           </span>
-          {dueDate && (
+          {dueDateIso && (
             <>
               <Text as="span" className="text-gray-600">·</Text>
-              <Text as="span" className="text-gray-400">Due {dueDate}</Text>
+              <Text as="span" className="text-gray-400">
+                Due <FormattedDate iso={dueDateIso} format="dueDate" />
+              </Text>
             </>
           )}
         </div>

--- a/apps/web/app/dashboard/data-fetchers.ts
+++ b/apps/web/app/dashboard/data-fetchers.ts
@@ -55,14 +55,8 @@ export async function fetchHeroData(projectId: string, projectSlug: string) {
   const phaseCloses = currentRound.dateLabels[currentRound.phase]?.closes;
   const timeRemaining = formatTimeRemaining(phaseCloses);
   const urgencyLevel = calculateUrgencyLevel(phaseCloses);
-  const dueDate = phaseCloses ? new Date(phaseCloses).toLocaleDateString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  }) : undefined;
+  // Pass raw ISO; clients format in user's local timezone via <FormattedDate>.
+  const dueDateIso = phaseCloses || undefined;
 
   const heroData = {
     roundId: currentRound.roundId,
@@ -78,7 +72,7 @@ export async function fetchHeroData(projectId: string, projectSlug: string) {
     submitCtaLabel: projectConfig.content.pages.dashboard.submissionCtaLabel,
     // Countdown/deadline data
     timeRemaining,
-    dueDate,
+    dueDateIso,
     urgencyLevel,
     // User progress
     hasSignedUp: roundDetails?.hasSignedUp || false,
@@ -166,14 +160,8 @@ export async function fetchActionData(projectId: string, projectSlug: string) {
   const phaseCloses = dateLabels[phase]?.closes;
   const timeRemaining = formatTimeRemaining(phaseCloses);
   const urgencyLevel = calculateUrgencyLevel(phaseCloses);
-  const dueDate = phaseCloses ? new Date(phaseCloses).toLocaleDateString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true
-  }) : undefined;
+  // Pass raw ISO; clients format in user's local timezone via <FormattedDate>.
+  const dueDateIso = phaseCloses || undefined;
 
   // Use project-specific terminology
   const phaseNames: Record<Phase, string> = {
@@ -214,7 +202,7 @@ export async function fetchActionData(projectId: string, projectSlug: string) {
           phaseName: phaseNames[phase as Phase],
           phaseMessage: phaseMessages[phase as Phase],
           timeRemaining,
-          dueDate,
+          dueDateIso,
           urgencyLevel,
           hasSignedUp: roundDetails?.hasSignedUp || false,
           hasSubmitted: roundDetails?.hasSubmitted || false,
@@ -246,7 +234,7 @@ export async function fetchActionData(projectId: string, projectSlug: string) {
         phaseName: phaseNames[phase as Phase],
         phaseMessage: phaseMessages[phase as Phase],
         timeRemaining,
-        dueDate,
+        dueDateIso,
         urgencyLevel,
         hasSignedUp: roundDetails?.hasSignedUp || false,
         hasSubmitted: roundDetails?.hasSubmitted || false,
@@ -270,7 +258,7 @@ export async function fetchActionData(projectId: string, projectSlug: string) {
             phaseName: phaseNames[phase as Phase],
             phaseMessage: phaseMessages[phase as Phase],
             timeRemaining,
-            dueDate,
+            dueDateIso,
             urgencyLevel,
             hasSignedUp: roundDetails?.hasSignedUp || false,
             hasSubmitted: roundDetails?.hasSubmitted || false,
@@ -292,7 +280,7 @@ export async function fetchActionData(projectId: string, projectSlug: string) {
           phaseName: phaseNames[phase as Phase],
           phaseMessage: phaseMessages[phase as Phase],
           timeRemaining,
-          dueDate,
+          dueDateIso,
           urgencyLevel,
           hasSignedUp: roundDetails?.hasSignedUp || false,
           hasSubmitted: roundDetails?.hasSubmitted || false,
@@ -315,7 +303,7 @@ export async function fetchActionData(projectId: string, projectSlug: string) {
           phaseName: phaseNames[phase as Phase],
           phaseMessage: phaseMessages[phase as Phase],
           timeRemaining,
-          dueDate,
+          dueDateIso,
           urgencyLevel,
           hasSignedUp: roundDetails?.hasSignedUp || false,
           hasSubmitted: roundDetails?.hasSubmitted || false,
@@ -336,7 +324,7 @@ export async function fetchActionData(projectId: string, projectSlug: string) {
         phaseName: phaseNames[phase as Phase],
         phaseMessage: phaseMessages[phase as Phase],
         timeRemaining,
-        dueDate,
+        dueDateIso,
         urgencyLevel,
         hasSignedUp: roundDetails?.hasSignedUp || false,
         hasSubmitted: roundDetails?.hasSubmitted || false,
@@ -359,7 +347,7 @@ export async function fetchActionData(projectId: string, projectSlug: string) {
           phaseName: phaseNames[phase as Phase],
           phaseMessage: phaseMessages[phase as Phase],
           timeRemaining,
-          dueDate,
+          dueDateIso,
           urgencyLevel,
           hasSignedUp: roundDetails?.hasSignedUp || false,
           hasSubmitted: roundDetails?.hasSubmitted || false,
@@ -380,7 +368,7 @@ export async function fetchActionData(projectId: string, projectSlug: string) {
         phaseName: phaseNames[phase as Phase],
         phaseMessage: phaseMessages[phase as Phase],
         timeRemaining,
-        dueDate,
+        dueDateIso,
         urgencyLevel,
         hasSignedUp: roundDetails?.hasSignedUp || false,
         hasSubmitted: roundDetails?.hasSubmitted || false,
@@ -399,7 +387,7 @@ export async function fetchActionData(projectId: string, projectSlug: string) {
         phaseName: phaseNames[phase as Phase],
         phaseMessage: phaseMessages[phase as Phase],
         timeRemaining,
-        dueDate,
+        dueDateIso,
         urgencyLevel,
         hasSignedUp: roundDetails?.hasSignedUp || false,
         hasSubmitted: roundDetails?.hasSubmitted || false,

--- a/apps/web/app/health/HealthBars.tsx
+++ b/apps/web/app/health/HealthBars.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from 'react';
 import {
+  FormattedDate,
   TooltipRoot,
   TooltipContent,
   TooltipProvider,
@@ -76,7 +77,7 @@ export default function HealthBars({ runs }: Props) {
                       </div>
                       <div className="flex justify-between">
                         <span className="text-gray-400">Time:</span>
-                        <span className="text-white">{new Date(run.startedAt).toLocaleString()}</span>
+                        <span className="text-white"><FormattedDate iso={run.startedAt} format="full" /></span>
                       </div>
                       {run.duration && (
                         <div className="flex justify-between">

--- a/apps/web/app/health/page.tsx
+++ b/apps/web/app/health/page.tsx
@@ -2,7 +2,7 @@ import { monitoringProvider } from "@eptss/core";
 import HealthBars from './HealthBars';
 import { Metadata } from 'next';
 
-import { Text } from "@eptss/ui";
+import { FormattedDate, Text } from "@eptss/ui";
 export const metadata: Metadata = {
   title: "System Health | Everyone Plays the Same Song",
   description: "System health and monitoring dashboard for Everyone Plays the Same Song platform",
@@ -44,7 +44,7 @@ export default async function HealthPage() {
                 >
                   <div className="flex justify-between items-center">
                     <Text as="span" weight="medium">{run.testName}</Text>
-                    <span>{new Date(run.startedAt).toLocaleTimeString()}</span>
+                    <FormattedDate iso={run.startedAt} format="time" />
                   </div>
                 </div>
               ))}

--- a/apps/web/app/projects/[projectSlug]/components/RoundInfoCard.tsx
+++ b/apps/web/app/projects/[projectSlug]/components/RoundInfoCard.tsx
@@ -4,7 +4,7 @@ import { motion } from "framer-motion";
 import React from "react";
 import { RoundInfo } from "@eptss/core/types/round";
 import { RoundInfoLabels } from "@eptss/project-config";
-import { Card, CardContent, Badge, Heading, Text } from "@eptss/ui";
+import { Card, CardContent, Badge, FormattedDate, Heading, Text } from "@eptss/ui";
 import { Sparkles } from "lucide-react";
 import { getDisplayRoundNumber } from "@/lib/roundDisplay";
 
@@ -30,42 +30,50 @@ export const RoundInfoCard = ({ roundInfo, labels }: RoundInfoCardProps) => {
     );
   }
 
-  const getPhaseContent = () => {
+  const buildInfo = (prefix: string, iso: string | undefined): React.ReactNode =>
+    iso ? <>{prefix} <FormattedDate iso={iso} format="full" /></> : "";
+
+  const getPhaseContent = (): {
+    badge: string;
+    title: string;
+    subtitle: string;
+    info: React.ReactNode;
+  } => {
     switch (roundInfo.phase) {
       case "signups":
         return {
           badge: labels.signups.badge,
           title: labels.signups.title,
           subtitle: labels.signups.subtitle,
-          info: `${labels.signups.closesPrefix} ${roundInfo.dateLabels?.signups?.closes ? new Date(roundInfo.dateLabels.signups.closes).toLocaleDateString() : ''}`
+          info: buildInfo(labels.signups.closesPrefix, roundInfo.dateLabels?.signups?.closes),
         };
       case "voting":
         return {
           badge: labels.voting.badge,
           title: labels.voting.title,
           subtitle: labels.voting.subtitle,
-          info: `${labels.voting.closesPrefix} ${roundInfo.dateLabels?.voting?.closes ? new Date(roundInfo.dateLabels.voting.closes).toLocaleDateString() : ''}`
+          info: buildInfo(labels.voting.closesPrefix, roundInfo.dateLabels?.voting?.closes),
         };
       case "covering":
         return {
           badge: labels.covering.badge,
           title: roundInfo.song?.title || labels.covering.titleFallback,
           subtitle: labels.covering.subtitle,
-          info: `${labels.covering.closesPrefix} ${roundInfo.dateLabels?.covering?.closes ? new Date(roundInfo.dateLabels.covering.closes).toLocaleDateString() : ''}`
+          info: buildInfo(labels.covering.closesPrefix, roundInfo.dateLabels?.covering?.closes),
         };
       case "celebration":
         return {
           badge: labels.celebration.badge,
           title: roundInfo.song?.title || labels.celebration.titleFallback,
           subtitle: labels.celebration.subtitle,
-          info: `${labels.celebration.closesPrefix} ${roundInfo.dateLabels?.celebration?.closes ? new Date(roundInfo.dateLabels.celebration.closes).toLocaleDateString() : ''}`
+          info: buildInfo(labels.celebration.closesPrefix, roundInfo.dateLabels?.celebration?.closes),
         };
       default:
         return {
           badge: labels.loading.badge,
           title: `Round ${getDisplayRoundNumber(roundInfo.roundId)}`,
           subtitle: "",
-          info: ""
+          info: "",
         };
     }
   };

--- a/apps/web/app/projects/[projectSlug]/sign-up/SignupPage/SignupForm.tsx
+++ b/apps/web/app/projects/[projectSlug]/sign-up/SignupPage/SignupForm.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
 import { useFormSubmission, FormWrapper, FormReturn } from "@eptss/forms"
-import { Button, Form, SectionHeader, AlertBox } from "@eptss/ui"
+import { Button, Form, FormattedDate, SectionHeader, AlertBox } from "@eptss/ui"
 import { motion } from "framer-motion"
 import { FormBuilder, FieldConfig } from "@eptss/ui"
 import { signupSchema, signupSchemaNoSong, nonLoggedInSchema, nonLoggedInSchemaNoSong, type SignupFormValues, type NonLoggedInSignupFormValues } from "@eptss/core/schemas/signupSchemas"
@@ -190,7 +190,12 @@ export function SignupForm({
   return (
     <FormWrapper
       title={title}
-      description={`Signups close ${new Date(signupsCloseDateLabel).toLocaleDateString()}${!isLoggedIn ? ' - Please provide your email to sign up' : ''}`}
+      description={
+        <>
+          Signups close <FormattedDate iso={signupsCloseDateLabel} format="full" />
+          {!isLoggedIn && ' - Please provide your email to sign up'}
+        </>
+      }
       onSubmit={handleSubmit}
     >
       <Form {...form}>

--- a/packages/core/src/services/dateService.ts
+++ b/packages/core/src/services/dateService.ts
@@ -1,4 +1,4 @@
-import { format, subDays, isBefore, parseISO, differenceInDays, differenceInHours, differenceInMinutes } from "date-fns";
+import { format, isBefore, parseISO, differenceInDays, differenceInHours, differenceInMinutes } from "date-fns";
 import { TZDate } from "@date-fns/tz";
 import { Phase } from "../types/round";
 
@@ -182,7 +182,7 @@ export const getPhaseDates = (dates: RoundDates, votingEnabled: boolean = true) 
       },
       covering: {
         opens: dates.votingOpens, // Start covering immediately after signups
-        closes: subDays(dates.coversDue, 1),
+        closes: dates.coversDue,
       },
       celebration: {
         opens: dates.coversDue,
@@ -198,11 +198,11 @@ export const getPhaseDates = (dates: RoundDates, votingEnabled: boolean = true) 
     },
     voting: {
       opens: dates.votingOpens,
-      closes: subDays(dates.coveringBegins, 1),
+      closes: dates.coveringBegins,
     },
     covering: {
       opens: dates.coveringBegins,
-      closes: subDays(dates.coversDue, 1),
+      closes: dates.coversDue,
     },
     celebration: {
       opens: dates.coversDue,

--- a/packages/dashboard/src/panels/HeroPanel.tsx
+++ b/packages/dashboard/src/panels/HeroPanel.tsx
@@ -1,6 +1,6 @@
 import { PanelProps } from '../types';
 import { Check, Clock, Send } from 'lucide-react';
-import { Badge, Card, CardContent, Display, Text, Label, Heading, Button } from '@eptss/ui';
+import { Badge, Card, CardContent, Display, Text, Label, Heading, Button, FormattedDate } from '@eptss/ui';
 import { getDisplayRoundNumber } from '@eptss/shared';
 
 interface HeroData {
@@ -32,7 +32,7 @@ interface HeroData {
   projectSlug?: string;
   // Countdown/deadline info
   timeRemaining?: string;
-  dueDate?: string;
+  dueDateIso?: string;
   urgencyLevel?: 'normal' | 'warning' | 'urgent';
   // User progress
   hasSignedUp?: boolean;
@@ -81,7 +81,7 @@ export function HeroPanel({ data }: PanelProps<HeroData>) {
     promptText,
     projectSlug,
     timeRemaining,
-    dueDate,
+    dueDateIso,
     urgencyLevel = 'normal',
     hasSignedUp,
     hasVoted,
@@ -243,7 +243,7 @@ export function HeroPanel({ data }: PanelProps<HeroData>) {
       {/* Bottom Content Group - pushed to bottom */}
       <div className="mt-auto space-y-6">
         {/* Deadline Section */}
-        {timeRemaining && dueDate && (
+        {timeRemaining && dueDateIso && (
           <div className="flex items-start gap-3 p-4 bg-[var(--color-gray-900)]/40 border border-[var(--color-gray-800)] rounded-lg">
             <Clock className="w-5 h-5 text-[var(--color-accent-primary)] mt-0.5" />
             <div>
@@ -251,7 +251,7 @@ export function HeroPanel({ data }: PanelProps<HeroData>) {
                 {getDeadlineLabel()}
               </Text>
               <Label size="xs" color="secondary" as="p">
-                {dueDate}
+                <FormattedDate iso={dueDateIso} format="dueDate" />
               </Label>
             </div>
             <div className="ml-auto text-right">

--- a/packages/rounds/src/components/RoundDatesDisplay.tsx
+++ b/packages/rounds/src/components/RoundDatesDisplay.tsx
@@ -2,10 +2,10 @@
 
 import { useState } from "react";
 import { Round } from "@eptss/core/services/roundService";
-import { format, subMilliseconds } from "date-fns";
 import { CalendarIcon } from "lucide-react";
 import {
   Button,
+  FormattedDate,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -87,10 +87,7 @@ export const RoundDatesDisplayPopup = ({ current, next }: Props) => {
               <TableRow key={name}>
                 <TableCell className="text-sm text-gray-300">{name}</TableCell>
                 <TableCell className="text-sm text-gray-300">
-                  {format(
-                    subMilliseconds(new Date(date), 1),
-                    "EEEE, MMMM do, yyyy"
-                  )}
+                  <FormattedDate iso={date} format="longDate" />
                 </TableCell>
               </TableRow>
             ))}

--- a/packages/rounds/src/components/RoundInfoDisplay.tsx
+++ b/packages/rounds/src/components/RoundInfoDisplay.tsx
@@ -3,7 +3,7 @@
 import { motion } from "framer-motion";
 import React from "react";
 import { RoundInfo } from "@eptss/core/types/round";
-import { Card, CardContent } from "@eptss/ui";
+import { Card, CardContent, FormattedDate } from "@eptss/ui";
 import { getDisplayRoundNumber } from "@eptss/shared";
 
 export const RoundInfoDisplay = ({ roundInfo }: { roundInfo: RoundInfo | null }) => {
@@ -28,42 +28,50 @@ export const RoundInfoDisplay = ({ roundInfo }: { roundInfo: RoundInfo | null })
     );
   }
 
-  const getPhaseContent = () => {
+  const buildInfo = (prefix: string, iso: string | undefined): React.ReactNode =>
+    iso ? <>{prefix} <FormattedDate iso={iso} format="full" /></> : "";
+
+  const getPhaseContent = (): {
+    badge: string;
+    title: string;
+    subtitle: string;
+    info: React.ReactNode;
+  } => {
     switch (roundInfo.phase) {
       case "signups":
         return {
           badge: "Signups Open",
           title: `Round ${getDisplayRoundNumber(roundInfo.roundId)} Signups`,
           subtitle: "Join our next round",
-          info: `Signups close ${roundInfo.dateLabels?.signups?.closes ? new Date(roundInfo.dateLabels.signups.closes).toLocaleDateString() : ''}`
+          info: buildInfo("Signups close", roundInfo.dateLabels?.signups?.closes),
         };
       case "voting":
         return {
           badge: "Voting Open",
           title: "Vote for the Next Song",
           subtitle: "Help choose our next cover",
-          info: `Voting closes ${roundInfo.dateLabels?.voting?.closes ? new Date(roundInfo.dateLabels.voting.closes).toLocaleDateString() : ''}`
+          info: buildInfo("Voting closes", roundInfo.dateLabels?.voting?.closes),
         };
       case "covering":
         return {
           badge: "Now Covering",
           title: roundInfo.song?.title || "Song Selected",
           subtitle: roundInfo.song?.artist ? `by ${roundInfo.song.artist}` : "",
-          info: `Covers due ${roundInfo.dateLabels?.covering?.closes ? new Date(roundInfo.dateLabels.covering.closes).toLocaleDateString() : ''}`
+          info: buildInfo("Covers due", roundInfo.dateLabels?.covering?.closes),
         };
       case "celebration":
         return {
           badge: "Celebration Phase",
           title: roundInfo.song?.title || "Covers Complete",
           subtitle: roundInfo.song?.artist ? `by ${roundInfo.song.artist}` : "",
-          info: `Celebration ends ${roundInfo.dateLabels?.celebration?.closes ? new Date(roundInfo.dateLabels.celebration.closes).toLocaleDateString() : ''}`
+          info: buildInfo("Celebration ends", roundInfo.dateLabels?.celebration?.closes),
         };
       default:
         return {
           badge: "Round Info",
           title: `Round ${getDisplayRoundNumber(roundInfo.roundId)}`,
           subtitle: "",
-          info: ""
+          info: "",
         };
     }
   };

--- a/packages/rounds/src/services/dateService.ts
+++ b/packages/rounds/src/services/dateService.ts
@@ -1,4 +1,4 @@
-import { format, subDays, isBefore, parseISO, differenceInDays, differenceInHours, differenceInMinutes } from "date-fns";
+import { format, isBefore, parseISO, differenceInDays, differenceInHours, differenceInMinutes } from "date-fns";
 import { TZDate } from "@date-fns/tz";
 import { Phase } from "../types/round";
 
@@ -182,7 +182,7 @@ export const getPhaseDates = (dates: RoundDates, votingEnabled: boolean = true) 
       },
       covering: {
         opens: dates.votingOpens, // Start covering immediately after signups
-        closes: subDays(dates.coversDue, 1),
+        closes: dates.coversDue,
       },
       celebration: {
         opens: dates.coversDue,
@@ -198,11 +198,11 @@ export const getPhaseDates = (dates: RoundDates, votingEnabled: boolean = true) 
     },
     voting: {
       opens: dates.votingOpens,
-      closes: subDays(dates.coveringBegins, 1),
+      closes: dates.coveringBegins,
     },
     covering: {
       opens: dates.coveringBegins,
-      closes: subDays(dates.coversDue, 1),
+      closes: dates.coversDue,
     },
     celebration: {
       opens: dates.coversDue,

--- a/packages/ui/src/components/FormattedDate.tsx
+++ b/packages/ui/src/components/FormattedDate.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type DateFormat =
+  | "compact"      // "May 10, 2026"
+  | "verbose"      // "May 10, 2026" (long month)
+  | "full"         // "May 10, 2026 at 5:00 PM"
+  | "dueDate"      // "Sat, May 10, 5:00 PM"
+  | "time"         // "5:00 PM"
+  | "monthYear"    // "May 2026"
+  | "longDate";    // "Sunday, May 10, 2026"
+
+const OPTIONS: Record<Exclude<DateFormat, "full">, Intl.DateTimeFormatOptions> = {
+  compact:   { year: "numeric", month: "short", day: "numeric" },
+  verbose:   { year: "numeric", month: "long",  day: "numeric" },
+  dueDate:   { weekday: "short", month: "short", day: "numeric", hour: "numeric", minute: "2-digit", hour12: true },
+  time:      { hour: "numeric", minute: "2-digit", hour12: true },
+  monthYear: { year: "numeric", month: "short" },
+  longDate:  { weekday: "long", year: "numeric", month: "long", day: "numeric" },
+};
+
+export function formatDateForUser(date: Date, format: DateFormat): string {
+  if (format === "full") {
+    const datePart = new Intl.DateTimeFormat("en-US", OPTIONS.compact).format(date);
+    const timePart = new Intl.DateTimeFormat("en-US", OPTIONS.time).format(date);
+    return `${datePart} at ${timePart}`;
+  }
+  return new Intl.DateTimeFormat("en-US", OPTIONS[format]).format(date);
+}
+
+export interface FormattedDateProps {
+  iso: string | Date | null | undefined;
+  format?: DateFormat;
+  fallback?: string;
+  className?: string;
+}
+
+export function FormattedDate({
+  iso,
+  format = "compact",
+  fallback = "",
+  className,
+}: FormattedDateProps) {
+  const [text, setText] = useState<string>(fallback);
+
+  useEffect(() => {
+    if (!iso) {
+      setText(fallback);
+      return;
+    }
+    const date = typeof iso === "string" ? new Date(iso) : iso;
+    if (isNaN(date.getTime())) {
+      setText(fallback);
+      return;
+    }
+    setText(formatDateForUser(date, format));
+  }, [iso, format, fallback]);
+
+  const dateTimeAttr = !iso
+    ? undefined
+    : typeof iso === "string"
+      ? iso
+      : iso.toISOString();
+
+  return (
+    <time dateTime={dateTimeAttr} className={className} suppressHydrationWarning>
+      {text}
+    </time>
+  );
+}

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -27,6 +27,7 @@ export * from './LoadingSpinner';
 export * from './BackgroundPattern';
 export * from './DataTable';
 export * from './StickyFooter';
+export * from './FormattedDate';
 
 // Re-export utility
 export { cn } from '../lib/utils';


### PR DESCRIPTION
## Summary

- The dashboard was rendering deadlines server-side via `.toLocaleDateString('en-US', {...})`. On Vercel, server `TZ=UTC`, so users in any other timezone saw the UTC clock face — and when combined with the `subDays(closes, 1)` "inclusive last day" hack in `getPhaseDates`, the displayed time landed on `12:00 AM the day before` the actual deadline. That's the visible off-by-one.
- Pre-formatted `dueDate: string` was passed from server → client, so clients had no opportunity to re-localize.
- Audit also turned up the same UTC-rendered-as-local bug in `RoundInfoCard`, `RoundInfoDisplay`, `SignupForm`, the admin rounds page, and the health dashboard.

Fix: always pass raw ISO from the server; format on the client where `Intl.DateTimeFormat` resolves to the user's actual timezone.

### What changed
- **New** `packages/ui/src/components/FormattedDate.tsx` — client component that accepts ISO + format preset (`compact`, `verbose`, `full`, `dueDate`, `time`, `monthYear`, `longDate`). Uses semantic `<time dateTime>` element. Initial render uses `fallback` to avoid hydration mismatch; replaces on `useEffect` mount.
- **Deleted** `subDays(..., 1)` in `getPhaseDates` (both `packages/rounds/src/services/dateService.ts` and the duplicate at `packages/core/src/services/dateService.ts`). Voting/covering phase `closes` is now the real boundary instant, not 24h before.
- **Deleted** `subMilliseconds(new Date(date), 1)` hack in `RoundDatesDisplay.tsx`.
- **Dashboard pipeline** (`data-fetchers.ts` → `HeroPanel` / `CountdownBarWrapper` / `ActionPanelWrapper`): pre-formatted `dueDate: string` → raw `dueDateIso: string`, rendered with `<FormattedDate format="dueDate">`.
- **Other surfaces** swapped server-side `.toLocaleDateString()` / `.toLocaleString()` for `<FormattedDate>`: `RoundInfoCard`, `RoundInfoDisplay`, `SignupForm`, `admin/rounds/[slug]/page.tsx` (3 sites in a `DataTable`), `health/page.tsx`, `HealthBars.tsx`.

### Out of scope
- Email templates (`PhaseReminder.tsx`) still use the rounds `formatDate` service. Emails are server-rendered with no client — needs a different approach (persist user's TZ at send-time, or default).
- Notifications using `formatDistanceToNow` — already correct (TZ-agnostic deltas).
- The inline duplicated `formatDate()` in `ClientRoundsDisplay.tsx` and `SubmissionsGallery.tsx` — date-only month/year renders, benign for typical 1st-of-month round start dates.

## Test plan

- [ ] Set browser timezone to UTC, open dashboard during an active round → "Due …" matches the admin-stored boundary
- [ ] Set browser timezone to America/Los_Angeles → "Due …" shifts back 7–8 hours from UTC display, lands on previous calendar day when boundary is near UTC midnight
- [ ] Set browser timezone to Asia/Tokyo → "Due …" shifts forward 9 hours
- [ ] No hydration mismatch warnings in console on dashboard, project pages, signup, admin rounds, health
- [ ] `RoundInfoCard` "Signups close / Voting closes / Covers due / Celebration ends" all render with full date + local time
- [ ] `RoundDatesDisplay` popup shows the real boundary date, not "day before"
- [ ] Admin rounds page schedule table + individual votes timestamps reflect the viewer's local time
- [ ] Health dashboard recent runs (page) and tooltip (HealthBars) show local time

🤖 Generated with [Claude Code](https://claude.com/claude-code)