### PR TITLE
plyr-link submissions: resolve a pasted track into a user-owned at.atjam.submission

### DIFF
--- a/apps/web/app/projects/[projectSlug]/submit/SubmitPage/SubmitPage.tsx
+++ b/apps/web/app/projects/[projectSlug]/submit/SubmitPage/SubmitPage.tsx
@@ -2,26 +2,15 @@
 
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useForm } from "react-hook-form"
-import { useReducer, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { FormWrapper, FormReturn } from "@eptss/forms"
-import { Button, Form, FormLabel, Text, Textarea, toast } from "@eptss/ui"
+import { Button, Form, FormLabel, Input, Text, Textarea, toast } from "@eptss/ui"
 import { motion } from "framer-motion"
 import { FormBuilder, FieldConfig } from "@eptss/ui";
 import { submissionFormSchema, type SubmissionInput } from "@eptss/core/schemas/submission"
 import type { ExistingSubmission } from "@eptss/core"
 import { PageContent, SubmissionFormConfig } from "@eptss/project-config";
-import {
-  MediaUploader,
-  uploadReducer,
-  initialUploadState,
-  canSubmit,
-  deriveSubmitConfig,
-  buildPayload,
-  payloadToFormData,
-  type UploadState,
-} from "@eptss/media-upload";
-import { BUCKETS } from "@eptss/bucket-storage";
 import { routes } from "@eptss/routing";
 
 interface Props {
@@ -87,6 +76,14 @@ const getFormFields = (isOriginal: boolean, config: SubmissionFormConfig): Field
   return fields;
 };
 
+/**
+ * The submission form. Going forward every submission is a plyr track: the user uploads
+ * their song to plyr.fm directly and pastes the track link here. The server
+ * (submitPlyrCover) resolves it to the fm.plyr.track in their own repo and writes the
+ * at.atjam.submission with that record as the deliverable — there is no upload here.
+ * (Past audio is re-hosted separately by migrate-to-plyr; that path doesn't touch this
+ * form.)
+ */
 export const SubmitPage = ({
   projectSlug,
   roundId,
@@ -101,95 +98,38 @@ export const SubmitPage = ({
   const router = useRouter();
   const { coverClosesLabel, listeningPartyLabel } = dateStrings;
 
-  // Validation errors
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // Get field configs for easier access
-  const audioConfig = submissionFormConfig.fields.audioFile;
-  const coverImageConfig = submissionFormConfig.fields.coverImage;
   const lyricsConfig = submissionFormConfig.fields.lyrics;
 
-  // Derive submit config from form config (what's required)
-  const submitConfig = deriveSubmitConfig(submissionFormConfig);
-
-  // Compute initial upload states from existing submission
-  const initialAudioState: UploadState = existingSubmission?.audioFileUrl
-    ? {
-        file: null,
-        status: 'complete',
-        progress: 100,
-        result: {
-          url: existingSubmission.audioFileUrl,
-          path: existingSubmission.audioFilePath || '',
-          fileSize: existingSubmission.audioFileSize ?? undefined,
-          metadata: existingSubmission.audioDuration
-            ? { audio: { duration: existingSubmission.audioDuration } }
-            : undefined,
-        },
-        error: null,
-      }
-    : initialUploadState;
-
-  const initialImageState: UploadState = existingSubmission?.coverImageUrl
-    ? {
-        file: null,
-        status: 'complete',
-        progress: 100,
-        result: {
-          url: existingSubmission.coverImageUrl,
-          path: existingSubmission.coverImagePath || '',
-        },
-        error: null,
-      }
-    : initialUploadState;
-
-  // Upload state - using reducers for explicit state tracking
-  // MediaUploader handles the actual upload, we just track state via callbacks
-  const [audioState, dispatchAudio] = useReducer(uploadReducer, initialAudioState);
-  const [imageState, dispatchImage] = useReducer(uploadReducer, initialImageState);
-
-  // Form for text fields only (what react-hook-form is good at)
   const form = useForm<SubmissionInput>({
     resolver: zodResolver(submissionFormSchema),
     defaultValues: {
-      audioFileUrl: existingSubmission?.audioFileUrl || "",
-      audioFilePath: existingSubmission?.audioFilePath || "",
-      coverImageUrl: existingSubmission?.coverImageUrl || "",
-      coverImagePath: existingSubmission?.coverImagePath || "",
-      audioDuration: existingSubmission?.audioDuration ?? undefined,
-      audioFileSize: existingSubmission?.audioFileSize ?? undefined,
+      // The track link + caption are re-entered each time (we store the resolved
+      // record, not the pasted URL); the reflections come back from Postgres.
+      plyrTrackUrl: "",
+      note: "",
       lyrics: existingSubmission?.lyrics || "",
       coolThingsLearned: existingSubmission?.coolThingsLearned || "",
       toolsUsed: existingSubmission?.toolsUsed || "",
       happyAccidents: existingSubmission?.happyAccidents || "",
       didntWork: existingSubmission?.didntWork || "",
-      roundId
+      roundId,
     },
   })
 
-  // Watch lyrics for the audio-or-lyrics validation
-  const lyrics = form.watch("lyrics");
-  const hasLyrics = Boolean(lyrics?.trim());
-
-  // Check if form can be submitted using pure function
-  const submitCheck = canSubmit(
-    { audio: audioState, image: imageState },
-    submitConfig,
-    hasLyrics
-  );
+  const hasPlyrUrl = Boolean(form.watch("plyrTrackUrl")?.trim());
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    // Check upload status first
-    if (!submitCheck.allowed) {
-      setValidationErrors(submitCheck.errors);
+    if (!hasPlyrUrl) {
+      setValidationErrors(["Paste your plyr track link."]);
       return;
     }
     setValidationErrors([]);
 
-    // Validate text fields with react-hook-form
     const isValid = await form.trigger();
     if (!isValid) {
       const errorMessages = Object.values(form.formState.errors)
@@ -204,30 +144,20 @@ export const SubmitPage = ({
     }
 
     setIsSubmitting(true);
-
     try {
-      // Build payload from upload states + text fields
-      const textFields = form.getValues();
-      const payload = buildPayload(
-        roundId,
-        { audio: audioState, image: imageState },
-        {
-          lyrics: textFields.lyrics,
-          coolThingsLearned: textFields.coolThingsLearned,
-          toolsUsed: textFields.toolsUsed,
-          happyAccidents: textFields.happyAccidents,
-          didntWork: textFields.didntWork,
-        }
-      );
+      const v = form.getValues();
+      const formData = new FormData();
+      formData.set("roundId", String(roundId));
+      formData.set("plyrTrackUrl", (v.plyrTrackUrl ?? "").trim());
+      if (v.note?.trim()) formData.set("note", v.note.trim());
+      if (v.lyrics?.trim()) formData.set("lyrics", v.lyrics);
+      for (const k of ["coolThingsLearned", "toolsUsed", "happyAccidents", "didntWork"] as const) {
+        const val = v[k];
+        if (val?.trim()) formData.set(k, val);
+      }
 
-      // Convert to FormData for server action
-      const formData = payloadToFormData(payload);
-
-      // Submit
       const result = await submitCover(formData);
-
       if (result.status === "Success") {
-        // Redirect to success page
         router.push(routes.projects.submit.success(projectSlug as "cover" | "monthly-original"));
       } else {
         toast({
@@ -271,17 +201,6 @@ export const SubmitPage = ({
 
   const formDescription = `${submitContent.formDescriptionPrefix} ${coverClosesLabel}`;
 
-  // Determine if audio is required based on config
-  const isAudioRequired = audioConfig.required || (audioConfig.requiredGroup && !lyricsConfig.enabled);
-
-  // Get upload status text
-  const getUploadStatusText = (state: UploadState) => {
-    if (state.status === 'uploading') return "Uploading...";
-    if (state.status === 'complete') return "Upload complete";
-    if (state.status === 'error') return "Upload failed";
-    return null;
-  };
-
   return (
     <FormWrapper
       title={formTitle}
@@ -295,8 +214,6 @@ export const SubmitPage = ({
           transition={{ duration: 0.5, delay: 0.2 }}
           className="space-y-6"
         >
-          <input type="hidden" name="roundId" value={roundId} />
-
           {/* Validation Errors */}
           {validationErrors.length > 0 && (
             <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
@@ -308,162 +225,39 @@ export const SubmitPage = ({
             </div>
           )}
 
-          {/* Audio Upload - only show if enabled */}
-          {audioConfig.enabled && (
-            <div className="space-y-2">
-              <FormLabel htmlFor="audio-upload">
-                {audioConfig.label || "Audio File"}{" "}
-                {isAudioRequired && <span className="text-red-500">*</span>}
-                {audioConfig.requiredGroup && !audioConfig.required && (
-                  <Text as="span" size="sm" color="muted"> (or provide lyrics)</Text>
-                )}
-              </FormLabel>
-              <Text size="sm" color="muted">
-                {existingSubmission?.audioFileUrl
-                  ? "Replace your existing audio file or keep the current one"
-                  : song.title !== null ? "Upload your song" : "Upload your cover"}
-              </Text>
-              {existingSubmission?.audioFileUrl && audioState.status === 'complete' && audioState.result?.url === existingSubmission.audioFileUrl && (
-                <div className="p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
-                  <Text size="sm" className="text-green-700 dark:text-green-400">
-                    ✓ Current audio file uploaded
-                  </Text>
-                </div>
-              )}
-              <MediaUploader
-                bucket={BUCKETS.AUDIO_SUBMISSIONS}
-                accept="audio/*"
-                maxSizeMB={audioConfig.maxSizeMB ?? 50}
-                variant="button"
-                buttonText="Choose Audio File"
-                showPreview={true}
-                onFilesSelected={(files) => {
-                  if (files.length > 0) {
-                    // Track that upload is starting
-                    dispatchAudio({ type: 'SELECT_FILE', file: files[0] });
-                    dispatchAudio({ type: 'UPLOAD_START' });
-                  }
-                }}
-                onFilesRemoved={() => {
-                  dispatchAudio({ type: 'CLEAR' });
-                }}
-                onUploadComplete={(results) => {
-                  if (results.length > 0) {
-                    const result = results[0];
-                    // Extract audio duration from metadata if available
-                    const audioDuration = result.metadata?.audio
-                      ? (result.metadata.audio as { duration?: number }).duration
-                      : undefined;
-                    dispatchAudio({
-                      type: 'UPLOAD_SUCCESS',
-                      result: {
-                        url: result.url,
-                        path: result.path,
-                        fileSize: result.fileSize,
-                        metadata: audioDuration ? { audio: { duration: audioDuration } } : undefined,
-                      },
-                    });
-                  }
-                }}
-                onUploadError={(error) => {
-                  dispatchAudio({ type: 'UPLOAD_ERROR', error: error.message });
-                  toast({
-                    variant: "destructive",
-                    title: "Audio Upload Error",
-                    description: error.message,
-                  });
-                }}
-              />
-              {/* Upload status feedback */}
-              {audioState.status !== 'idle' && (
-                <Text
-                  size="sm"
-                  color={audioState.status === 'complete' ? undefined : audioState.status === 'error' ? "destructive" : "muted"}
-                >
-                  {getUploadStatusText(audioState)}
-                </Text>
-              )}
-              {audioState.status === 'error' && audioState.error && (
-                <Text size="sm" color="destructive">{audioState.error}</Text>
-              )}
-            </div>
-          )}
+          {/* plyr track link — the deliverable */}
+          <div className="space-y-2">
+            <FormLabel htmlFor="plyrTrackUrl">
+              plyr track link <span className="text-red-500">*</span>
+            </FormLabel>
+            <Text size="sm" color="muted">
+              Upload your song to plyr.fm, then paste the track link here (e.g.
+              https://plyr.fm/track/123). We&apos;ll attach your plyr track — audio and
+              cover and all — to this round.
+            </Text>
+            <Input
+              id="plyrTrackUrl"
+              type="url"
+              inputMode="url"
+              placeholder="https://plyr.fm/track/…"
+              disabled={isSubmitting}
+              {...form.register("plyrTrackUrl")}
+            />
 
-          {/* Cover Image Upload - only show if enabled */}
-          {coverImageConfig.enabled && (
-            <div className="space-y-2">
-              <FormLabel htmlFor="cover-image-upload">
-                {coverImageConfig.label || "Cover Art"}{" "}
-                {coverImageConfig.required ? (
-                  <span className="text-red-500">*</span>
-                ) : (
-                  <Text as="span" size="sm" color="muted">(Optional)</Text>
-                )}
-              </FormLabel>
-              <Text size="sm" color="muted">
-                {existingSubmission?.coverImageUrl
-                  ? "Replace your existing cover image or keep the current one"
-                  : coverImageConfig.description || "Upload cover art for your submission (will use your profile picture if not provided)"}
-              </Text>
-              {existingSubmission?.coverImageUrl && imageState.status === 'complete' && imageState.result?.url === existingSubmission.coverImageUrl && (
-                <div className="p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
-                  <Text size="sm" className="text-green-700 dark:text-green-400">
-                    ✓ Current cover image uploaded
-                  </Text>
-                </div>
-              )}
-              <MediaUploader
-                bucket={BUCKETS.SUBMISSION_IMAGES}
-                accept="image/*"
-                maxSizeMB={coverImageConfig.maxSizeMB ?? 5}
-                enableCrop={false} // TODO: implement upload-then-crop flow
-                variant="button"
-                buttonText="Choose Cover Image"
-                showPreview={true}
-                onFilesSelected={(files) => {
-                  if (files.length > 0) {
-                    dispatchImage({ type: 'SELECT_FILE', file: files[0] });
-                    dispatchImage({ type: 'UPLOAD_START' });
-                  }
-                }}
-                onFilesRemoved={() => {
-                  dispatchImage({ type: 'CLEAR' });
-                }}
-                onUploadComplete={(results) => {
-                  if (results.length > 0) {
-                    const result = results[0];
-                    dispatchImage({
-                      type: 'UPLOAD_SUCCESS',
-                      result: {
-                        url: result.url,
-                        path: result.path,
-                      },
-                    });
-                  }
-                }}
-                onUploadError={(error) => {
-                  dispatchImage({ type: 'UPLOAD_ERROR', error: error.message });
-                  toast({
-                    variant: "destructive",
-                    title: "Image Upload Error",
-                    description: error.message,
-                  });
-                }}
-              />
-              {/* Upload status feedback */}
-              {imageState.status !== 'idle' && (
-                <Text
-                  size="sm"
-                  color={imageState.status === 'complete' ? undefined : imageState.status === 'error' ? "destructive" : "muted"}
-                >
-                  {getUploadStatusText(imageState)}
-                </Text>
-              )}
-              {imageState.status === 'error' && imageState.error && (
-                <Text size="sm" color="destructive">{imageState.error}</Text>
-              )}
-            </div>
-          )}
+            <FormLabel htmlFor="note" className="pt-2">
+              Caption{" "}
+              <Text as="span" size="sm" color="muted">(optional, shown publicly)</Text>
+            </FormLabel>
+            <Textarea
+              id="note"
+              {...form.register("note")}
+              placeholder="A short note about your cover (a sentence or two)…"
+              rows={2}
+              maxLength={1500}
+              disabled={isSubmitting}
+              className="w-full"
+            />
+          </div>
 
           {/* Lyrics Field - only show if enabled */}
           {lyricsConfig.enabled && (
@@ -471,9 +265,6 @@ export const SubmitPage = ({
               <FormLabel htmlFor="lyrics">
                 {lyricsConfig.label || "Lyrics"}{" "}
                 {lyricsConfig.required && <span className="text-red-500">*</span>}
-                {lyricsConfig.requiredGroup && !lyricsConfig.required && (
-                  <Text as="span" size="sm" color="muted"> (or provide audio)</Text>
-                )}
               </FormLabel>
               {lyricsConfig.description && (
                 <Text size="sm" color="muted">
@@ -497,16 +288,10 @@ export const SubmitPage = ({
             disabled={isSubmitting}
           />
 
-          <Button
-            type="submit"
-            disabled={isSubmitting || submitCheck.pending.length > 0}
-            size="full"
-          >
+          <Button type="submit" disabled={isSubmitting} size="full">
             {isSubmitting
               ? existingSubmission ? "Updating..." : submitContent.submittingText
-              : submitCheck.pending.length > 0
-                ? "Waiting for uploads..."
-                : existingSubmission ? "Update Submission" : submitContent.submitButtonText}
+              : existingSubmission ? "Update Submission" : submitContent.submitButtonText}
           </Button>
         </motion.div>
       </Form>

--- a/apps/web/app/projects/[projectSlug]/submit/[roundId]/page.tsx
+++ b/apps/web/app/projects/[projectSlug]/submit/[roundId]/page.tsx
@@ -1,5 +1,5 @@
 import { roundProvider, userParticipationProvider, getProjectIdFromSlug, type ProjectSlug, getUserSubmissionForRound } from "@eptss/core";
-import { submitCover } from "@/actions/userParticipationActions";
+import { submitPlyrCover } from "@/lib/atproto/submit-actions";
 import { SubmitPage } from "../SubmitPage";
 import { getProjectConfig } from "@eptss/project-config";
 
@@ -41,7 +41,7 @@ export default async function SubmitForRound({ params }: Props) {
       hasSubmitted={roundDetails?.hasSubmitted || false}
       existingSubmission={existingSubmission}
       song={song}
-      submitCover={submitCover}
+      submitCover={submitPlyrCover}
       submitContent={projectConfig.content.pages.submit}
       submissionFormConfig={projectConfig.submissionForm}
     />

--- a/apps/web/app/projects/[projectSlug]/submit/page.tsx
+++ b/apps/web/app/projects/[projectSlug]/submit/page.tsx
@@ -1,6 +1,6 @@
 import { roundProvider, userParticipationProvider, getProjectIdFromSlug, isValidProjectSlug, type ProjectSlug, getUserSubmissionForRound } from "@eptss/core";
 import { getProjectSEOMetadata, getPageContent, getProjectConfig } from "@eptss/project-config";
-import { submitCover } from "@/actions/userParticipationActions";
+import { submitPlyrCover } from "@/lib/atproto/submit-actions";
 import { SubmitPage } from "./SubmitPage";
 import { Metadata } from 'next';
 
@@ -79,7 +79,7 @@ const Submit = async ({ params }: Props) => {
         coverClosesLabel,
         listeningPartyLabel,
       }}
-      submitCover={submitCover}
+      submitCover={submitPlyrCover}
       submitContent={submitContent}
       submissionFormConfig={projectConfig.submissionForm}
     />

--- a/apps/web/lib/atproto/migrate-core.ts
+++ b/apps/web/lib/atproto/migrate-core.ts
@@ -113,32 +113,32 @@ export async function ensurePlyrTrackOwned(opts: {
 }
 
 /**
- * Write the cover's at.atjam.submission into the user's repo (upsert at its stable
- * rkey, read back to prove it resolves). Round / note / createdAt come from the
- * scaffold copy the backfill wrote — only the *deliverable* changes: the plyr
- * strong-ref when there is one, else the scaffold's legacy `url`, so a cover always
- * carries exactly one deliverable. Returns the written ref.
+ * The single home for "write an at.atjam.submission into a user's repo": upsert at the
+ * stable `eptss-sub<id>` rkey and read it back to prove it resolves. The deliverable is
+ * the plyr strong-ref when there is one (`payload`), else the legacy `url` — a
+ * submission always carries exactly one — and an optional caption rides along as `note`.
+ * Pure (no Postgres) and agent-injected, so both the cover migration (record built from
+ * a scaffold) and a native submit (record built from the round) flow through it and stay
+ * in lockstep. Idempotent on the rkey; returns the written ref.
  */
-export async function writeOwnedSubmission(opts: {
+export async function writeSubmissionRecord(opts: {
   agent: Agent;
   did: string;
   submissionId: number;
-  source: Submission;
-  plyrRef: StrongRef | null;
+  round: StrongRef;
+  /** Preferred deliverable; falls back to `url` when absent. */
+  plyrRef?: StrongRef | null;
+  url?: string | null;
+  note?: string | null;
+  createdAt: string;
 }): Promise<StrongRef> {
-  const { agent, did, submissionId, source, plyrRef } = opts;
+  const { agent, did, submissionId, round, plyrRef, url, note, createdAt } = opts;
   const rkey = eptssSubmissionRkey(submissionId);
 
-  const record: Record<string, unknown> = {
-    $type: SUBMISSION_COLLECTION,
-    round: source.round,
-    ...(source.note ? { note: source.note } : {}),
-    createdAt: source.createdAt,
-  };
-  // Prefer the plyr record as the artifact; the raw `url` is only a fallback for a
-  // cover with no plyr track (an at.atjam.submission needs a deliverable).
+  const record: Record<string, unknown> = { $type: SUBMISSION_COLLECTION, round, createdAt };
   if (plyrRef) record.payload = plyrRef;
-  else if (source.url) record.url = source.url;
+  else if (url) record.url = url;
+  if (note) record.note = note;
 
   const put = await agent.com.atproto.repo.putRecord({
     repo: did,
@@ -152,4 +152,29 @@ export async function writeOwnedSubmission(opts: {
     rkey,
   });
   return { uri: put.data.uri, cid: put.data.cid };
+}
+
+/**
+ * Write a migrated cover's at.atjam.submission from its admin-scaffold copy: round /
+ * note / createdAt carried from the scaffold, the deliverable upgraded to the plyr
+ * strong-ref (or the scaffold's legacy `url`). A thin adapter over writeSubmissionRecord.
+ */
+export async function writeOwnedSubmission(opts: {
+  agent: Agent;
+  did: string;
+  submissionId: number;
+  source: Submission;
+  plyrRef: StrongRef | null;
+}): Promise<StrongRef> {
+  const { agent, did, submissionId, source, plyrRef } = opts;
+  return writeSubmissionRecord({
+    agent,
+    did,
+    submissionId,
+    round: source.round,
+    plyrRef,
+    url: source.url ?? null,
+    note: source.note ?? null,
+    createdAt: source.createdAt,
+  });
 }

--- a/apps/web/lib/atproto/submit-actions.ts
+++ b/apps/web/lib/atproto/submit-actions.ts
@@ -1,0 +1,177 @@
+"use server";
+
+/**
+ * Native plyr submission — the submission flow going forward.
+ *
+ * The user uploads their song to plyr.fm directly and pastes the track link. We resolve
+ * it to the `fm.plyr.track` in their OWN repo and write the `at.atjam.submission`
+ * straight into their PDS, with `payload` → that track. No Supabase upload, no admin
+ * scaffold, no later claim step: the deliverable is born owned. (The upload path lives
+ * on only for past records — `migrate-to-plyr` + the claim flow.)
+ *
+ * Order is deliberate — PDS first. The `at.atjam.submission` record is written and read
+ * back BEFORE the Postgres row is touched, so a failed network write leaves nothing
+ * half-done; the user just retries (the stable `eptss-sub<id>` rkey upserts). Only once
+ * the record resolves do we record the Postgres row + crosswalk.
+ *
+ * Requires a linked Bluesky account: the ownership guard (the plyr track must be the
+ * submitter's own) needs their DID, and the record is written to their repo.
+ *
+ * Per the lexicon, `note` is a short public caption (≤300 graphemes); the long-form
+ * reflection prompts stay in Postgres `additional_comments`, where they always lived.
+ */
+
+import { revalidatePath } from "next/cache";
+import { getAuthUser } from "@eptss/auth/server";
+import { loadIdentity } from "@eptss/auth/atproto";
+import { db, submissions, roundMetadata, eq, and, desc } from "@eptss/db";
+import {
+  eptssRoundRkey,
+  getRoundRecord,
+  resolvePlyrUrlToRecord,
+  PlyrResolveError,
+  type StrongRef,
+} from "@eptss/atproto";
+import type { FormReturn } from "@eptss/forms";
+import { getUserAgent } from "./agent";
+import { writeSubmissionRecord } from "./migrate-core";
+
+const NOTE_MAX_GRAPHEMES = 300;
+
+const fail = (message: string): FormReturn => ({ status: "Error", message });
+
+/** Trim a caption to the lexicon's grapheme budget without splitting a glyph. */
+function clampGraphemes(text: string, max: number): string {
+  const seg = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+  const graphemes = [...seg.segment(text)].map((s) => s.segment);
+  if (graphemes.length <= max) return text;
+  return graphemes.slice(0, max).join("").trimEnd();
+}
+
+const str = (formData: FormData, key: string): string | undefined => {
+  const v = formData.get(key)?.toString().trim();
+  return v ? v : undefined;
+};
+
+/**
+ * Create (or update) a submission from a pasted plyr track link. Idempotent on the
+ * stable rkey, so a re-submit upserts the same record and refreshes the Postgres row.
+ */
+export async function submitPlyrCover(formData: FormData): Promise<FormReturn> {
+  try {
+    const { userId } = await getAuthUser();
+    if (!userId) return fail("You must be logged in to submit.");
+
+    const roundId = Number(formData.get("roundId"));
+    if (!Number.isInteger(roundId) || roundId <= 0) return fail("Missing round.");
+
+    const plyrTrackUrl = str(formData, "plyrTrackUrl");
+    if (!plyrTrackUrl) return fail("Paste your plyr track link.");
+
+    const identity = await loadIdentity(userId);
+    if (!identity) return fail("Link your Bluesky account before submitting.");
+
+    // 1. The round must already be on the network — an at.atjam.submission needs a
+    //    round strong-ref. A live round is always backfilled, so absence is exceptional.
+    const roundRec = await getRoundRecord(eptssRoundRkey(roundId));
+    if (!roundRec) return fail("This round isn't on the network yet — try again shortly.");
+
+    // 2. Resolve the pasted link to the user's own fm.plyr.track, then guard ownership.
+    let resolved;
+    try {
+      resolved = await resolvePlyrUrlToRecord(plyrTrackUrl);
+    } catch (e) {
+      if (e instanceof PlyrResolveError) return fail(e.message);
+      throw e;
+    }
+    if (resolved.artistDid !== identity.did) {
+      return fail("That plyr track belongs to a different account than your linked Bluesky.");
+    }
+
+    // The submission's stable rkey is keyed on the Postgres submission id, so we settle
+    // an id up front: reuse the user's existing row for this round (a re-submit), else
+    // reserve the next one. No write yet — the PDS record goes first.
+    const existing = await db
+      .select({ id: submissions.id })
+      .from(submissions)
+      .where(and(eq(submissions.roundId, roundId), eq(submissions.userId, userId)))
+      .limit(1);
+    let submissionId: number;
+    if (existing[0]) {
+      submissionId = existing[0].id;
+    } else {
+      const last = await db.select({ id: submissions.id }).from(submissions).orderBy(desc(submissions.id)).limit(1);
+      submissionId = (last[0]?.id ?? 0) + 1;
+    }
+
+    const note = str(formData, "note");
+
+    // 3. PDS FIRST — write the submission into the user's repo and prove it resolves,
+    //    via the shared writer so claim and submit stay in lockstep.
+    let agent;
+    try {
+      agent = await getUserAgent(identity.did);
+    } catch (e) {
+      console.error(`[submit-plyr] #${submissionId} session restore failed`, e);
+      return fail("Your Bluesky session expired — re-link and submit again.");
+    }
+    let written: StrongRef;
+    try {
+      written = await writeSubmissionRecord({
+        agent,
+        did: identity.did,
+        submissionId,
+        round: { uri: roundRec.uri, cid: roundRec.cid },
+        plyrRef: { uri: resolved.uri, cid: resolved.cid },
+        note: note ? clampGraphemes(note, NOTE_MAX_GRAPHEMES) : null,
+        createdAt: new Date().toISOString(),
+      });
+    } catch (e) {
+      console.error(`[submit-plyr] #${submissionId} record write failed`, e);
+      return fail("Couldn't write your submission to Bluesky — nothing was saved, please try again.");
+    }
+
+    // 4. THEN Postgres — the record exists, so record the row + crosswalk. The long-form
+    //    reflections live here; the public record carries only the short caption.
+    const projectRow = await db
+      .select({ projectId: roundMetadata.projectId })
+      .from(roundMetadata)
+      .where(eq(roundMetadata.id, roundId))
+      .limit(1);
+    const projectId = projectRow[0]?.projectId;
+    if (!projectId) return fail("Round not found.");
+
+    const additionalComments = JSON.stringify({
+      coolThingsLearned: str(formData, "coolThingsLearned") ?? "",
+      toolsUsed: str(formData, "toolsUsed") ?? "",
+      happyAccidents: str(formData, "happyAccidents") ?? "",
+      didntWork: str(formData, "didntWork") ?? "",
+    });
+    const row = {
+      // plyr hosts the audio + cover; keep the URLs for the legacy/display columns.
+      audioFileUrl: resolved.audioUrl ?? plyrTrackUrl,
+      audioFilePath: null,
+      coverImageUrl: resolved.imageUrl,
+      coverImagePath: null,
+      lyrics: str(formData, "lyrics") ?? null,
+      additionalComments,
+      // The deliverable lives in the user's repo now; record the crosswalk.
+      plyrTrackUri: resolved.uri,
+      plyrTrackCid: resolved.cid,
+      claimedAtUri: written.uri,
+      claimedAt: new Date(),
+    };
+    if (existing[0]) {
+      await db.update(submissions).set(row).where(eq(submissions.id, submissionId));
+    } else {
+      await db.insert(submissions).values({ id: submissionId, projectId, roundId, userId, ...row });
+    }
+
+    console.log(`[submit-plyr] #${submissionId} -> ${written.uri} (payload ${resolved.uri})`);
+    revalidatePath("/dashboard");
+    return { status: "Success", message: "" };
+  } catch (e) {
+    console.error("[submit-plyr] failed", e);
+    return fail(e instanceof Error ? e.message : "Submission failed. Please try again.");
+  }
+}

--- a/packages/atproto/src/plyr-resolve.test.ts
+++ b/packages/atproto/src/plyr-resolve.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { parsePlyrTrackId, resolvePlyrUrlToRecord, PlyrResolveError } from "./plyr";
+
+describe("parsePlyrTrackId", () => {
+  it("pulls the id from a track page, embed, and bare-number paste", () => {
+    expect(parsePlyrTrackId("https://plyr.fm/track/1147")).toBe(1147);
+    expect(parsePlyrTrackId("https://plyr.fm/embed/track/795")).toBe(795);
+    expect(parsePlyrTrackId("  1147 ")).toBe(1147);
+    // trailing slash / query string don't trip the match
+    expect(parsePlyrTrackId("https://plyr.fm/track/42/?ref=x")).toBe(42);
+  });
+
+  it("returns null for non-track plyr URLs and junk", () => {
+    // albums/playlists are handle/slug-based — not a track
+    expect(parsePlyrTrackId("https://plyr.fm/album/alice.bsky.social/demo")).toBeNull();
+    expect(parsePlyrTrackId("https://example.com/track/notanumber")).toBeNull();
+    expect(parsePlyrTrackId("")).toBeNull();
+  });
+});
+
+describe("resolvePlyrUrlToRecord", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const ok = (body: unknown) =>
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+
+  it("returns the strong-ref + owner + hosted media for an indexed track", async () => {
+    ok({
+      id: 795,
+      title: "Pioneer",
+      atproto_record_uri: "at://did:plc:abc/fm.plyr.track/3xyz",
+      atproto_record_cid: "bafyrecid",
+      artist_did: "did:plc:abc",
+      image_url: "https://images.plyr.fm/i/cover.jpg",
+      r2_url: "https://audio.plyr.fm/a/song.wav",
+    });
+    const r = await resolvePlyrUrlToRecord("https://plyr.fm/track/795");
+    expect(r).toEqual({
+      trackId: 795,
+      uri: "at://did:plc:abc/fm.plyr.track/3xyz",
+      cid: "bafyrecid",
+      artistDid: "did:plc:abc",
+      title: "Pioneer",
+      imageUrl: "https://images.plyr.fm/i/cover.jpg",
+      audioUrl: "https://audio.plyr.fm/a/song.wav",
+    });
+  });
+
+  it("rejects an unparseable URL before making any request", async () => {
+    const spy = vi.spyOn(globalThis, "fetch");
+    await expect(resolvePlyrUrlToRecord("https://plyr.fm/album/x/y")).rejects.toMatchObject({
+      reason: "unparseable",
+    });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("maps a 404 to a not-found PlyrResolveError", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 404 }));
+    await expect(resolvePlyrUrlToRecord("https://plyr.fm/track/9999")).rejects.toBeInstanceOf(
+      PlyrResolveError,
+    );
+    await expect(resolvePlyrUrlToRecord("https://plyr.fm/track/9999")).rejects.toMatchObject({
+      reason: "not-found",
+    });
+  });
+
+  it("flags a track that has no atproto record yet as not-indexed", async () => {
+    ok({ id: 1, title: "x", atproto_record_uri: null, atproto_record_cid: null, artist_did: null });
+    await expect(resolvePlyrUrlToRecord("https://plyr.fm/track/1")).rejects.toMatchObject({
+      reason: "not-indexed",
+    });
+  });
+});

--- a/packages/atproto/src/plyr.ts
+++ b/packages/atproto/src/plyr.ts
@@ -27,6 +27,101 @@ interface PlyrApiTrack {
   atproto_record_uri?: string;
 }
 
+/** A plyr track resolved from a user-pasted URL — the strong-ref plus the bits a
+ *  submission needs (owner DID for the ownership guard, hosted cover + audio). */
+export interface ResolvedPlyrTrack {
+  trackId: number;
+  /** The fm.plyr.track record's AT URI — the submission `payload` strong-ref uri. */
+  uri: string;
+  /** The record CID — the strong-ref cid. */
+  cid: string;
+  /** The track owner's DID; callers must confirm it matches the submitter. */
+  artistDid: string;
+  title: string | null;
+  /** plyr-hosted cover (images.plyr.fm) — already a trusted, renderable URL. */
+  imageUrl: string | null;
+  /** plyr-hosted streaming audio (R2). */
+  audioUrl: string | null;
+}
+
+/** Thrown when a pasted plyr URL can't become a submission deliverable. The
+ *  `reason` is a stable code so the submit flow can map it to user-facing copy. */
+export class PlyrResolveError extends Error {
+  constructor(
+    readonly reason: "unparseable" | "not-found" | "not-indexed",
+    message: string,
+  ) {
+    super(message);
+    this.name = "PlyrResolveError";
+  }
+}
+
+/**
+ * Pull the numeric track id out of a plyr URL the user pasted. Mirrors plyr's own
+ * oEmbed parser (`/track/(\d+)`), so it accepts the track page
+ * (`plyr.fm/track/123`) and the embed (`plyr.fm/embed/track/123`) alike; a bare
+ * numeric id is allowed too, for the paste-the-number case. Returns null when no
+ * track id is present — album/playlist URLs (`/album/{handle}/{slug}`) don't match.
+ */
+export function parsePlyrTrackId(input: string): number | null {
+  const trimmed = input.trim();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed);
+  const m = trimmed.match(/\/track\/(\d+)/);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Resolve a pasted plyr track URL to the `fm.plyr.track` it points at — the inverse
+ * of the migration. plyr already hosts the audio, cover, and record (the user
+ * uploaded there directly), so we only read its public `/tracks/{id}` API and hand
+ * back the strong-ref plus metadata. The caller must still confirm `artistDid` is the
+ * submitting user before assigning it as their deliverable. Throws `PlyrResolveError`
+ * with a stable reason on a bad URL, an unknown track, or a track not yet carrying an
+ * atproto record.
+ */
+export async function resolvePlyrUrlToRecord(
+  input: string,
+  opts: { apiBase?: string } = {},
+): Promise<ResolvedPlyrTrack> {
+  const trackId = parsePlyrTrackId(input);
+  if (trackId == null) {
+    throw new PlyrResolveError("unparseable", "That doesn't look like a plyr track link.");
+  }
+  const apiBase = (opts.apiBase ?? PLYR_API).replace(/\/$/, "");
+  const res = await fetch(`${apiBase}/tracks/${trackId}`);
+  if (res.status === 404) {
+    throw new PlyrResolveError("not-found", `No plyr track found at id ${trackId}.`);
+  }
+  if (!res.ok) {
+    throw new PlyrResolveError("not-found", `Couldn't reach plyr for track ${trackId} (${res.status}).`);
+  }
+  const t = (await res.json()) as {
+    id?: number;
+    title?: string | null;
+    atproto_record_uri?: string | null;
+    atproto_record_cid?: string | null;
+    artist_did?: string | null;
+    image_url?: string | null;
+    r2_url?: string | null;
+  };
+  if (!t.atproto_record_uri || !t.atproto_record_cid || !t.artist_did) {
+    // plyr indexes the row at upload, but the on-network record may lag a beat.
+    throw new PlyrResolveError(
+      "not-indexed",
+      "That track isn't on the network yet — give plyr a moment after uploading, then retry.",
+    );
+  }
+  return {
+    trackId,
+    uri: t.atproto_record_uri,
+    cid: t.atproto_record_cid,
+    artistDid: t.artist_did,
+    title: t.title ?? null,
+    imageUrl: t.image_url ?? null,
+    audioUrl: t.r2_url ?? null,
+  };
+}
+
 /**
  * Index a repo's plyr tracks by AT URI → plyr numeric id, so we can turn an
  * `fm.plyr.track` record URI into an embeddable player. Paginates plyr's public

--- a/packages/core/src/schemas/submission.ts
+++ b/packages/core/src/schemas/submission.ts
@@ -1,17 +1,15 @@
 import { z } from "zod";
-import { optionalPositiveNumber } from "./zodHelpers";
 
-// Form schema for client-side validation (text fields only)
-// Media fields are validated by canSubmit() using reducer state
-// This avoids async timing issues with form.setValue()
+// Client-side form schema for the submission form. Every submission is a plyr track:
+// the user pastes a plyr.fm track link (resolved server-side to the fm.plyr.track in
+// their repo) plus a short public caption; the rest is narrative text kept in Postgres.
 export const submissionFormSchema = z.object({
-  // Media fields are optional here - validated separately via canSubmit()
-  audioFileUrl: z.string().optional(),
-  audioFilePath: z.string().optional(),
-  coverImageUrl: z.string().optional(),
-  coverImagePath: z.string().optional(),
-  audioDuration: optionalPositiveNumber,
-  audioFileSize: optionalPositiveNumber,
+  // The deliverable: a plyr.fm track URL. The server resolves it to the fm.plyr.track
+  // in the user's repo and writes the at.atjam.submission with that record as payload.
+  plyrTrackUrl: z.string().optional(),
+  // Short public caption written onto the at.atjam.submission record (≤300 graphemes).
+  // The long-form reflection prompts below stay in Postgres.
+  note: z.string().optional(),
   // Text fields
   lyrics: z.string().optional(),
   coolThingsLearned: z.string().optional(),


### PR DESCRIPTION
## Why

Going forward, EPTSS submissions *are* plyr tracks. Rather than EPTSS uploading audio (and fighting plyr's image-hosting rules), the user uploads their song to **plyr.fm directly** and pastes the track link. We resolve that link to the `fm.plyr.track` in their **own** repo and write the `at.atjam.submission` straight into their PDS with `payload` → that track. No Supabase upload, no admin scaffold, no later claim step — the deliverable is born owned, audio + cover + working embed and all.

This is the inverse of the legacy migration, and dramatically simpler: a URL parse + one public GET + one record write.

## The flow

```
user uploads to plyr.fm → pastes the link → submitPlyrCover (server):
  loadIdentity            (require a linked Bluesky)
  resolve round strong-ref via getRoundRecord(eptssRoundRkey)   [hard error if round not on network]
  resolvePlyrUrlToRecord  + ownership guard (artist_did === linked DID)
  PDS-FIRST: putRecord at.atjam.submission (round, payload, note, createdAt) + read-back
  THEN Postgres: crosswalk (plyr_track_uri/cid, claimed_at_uri = written uri)
```

## What's here

- **`@eptss/atproto`** — `parsePlyrTrackId` + `resolvePlyrUrlToRecord` (+ typed `PlyrResolveError`), resolving a pasted plyr URL to its `fm.plyr.track` strong-ref via plyr's public `/tracks/{id}` API. Mirrors plyr's own `/track/(\d+)` parser. The package stays a **zero-dependency pure-read leaf**. 6 unit tests.
- **`apps/web/lib/atproto/submit-actions.ts`** — the native submit action (PDS-first, ownership-guarded, round-required).
- **`migrate-core.ts`** — extracted **one** `writeSubmissionRecord` ("put a submission record + read back"); `writeOwnedSubmission` (cover migration) and `submitPlyrCover` are thin adapters over it. No duplicate writer.
- **`SubmitPage`** — now plyr-only: a track-link field + a short public **caption** (`note`, clamped server-side to the lexicon's 300 graphemes). The Supabase uploader / `canSubmit` / reducer machinery is removed from the form (~−300 lines). The upload path stays intact for `adminSubmitCover` + `migrate-to-plyr`.

## Decisions baked in

1. **Round must already exist** — an `at.atjam.submission` requires a round strong-ref; if the round's record isn't on the network the submit hard-errors (shouldn't happen for a live round).
2. **PDS-first, then Postgres** — a failed network write leaves nothing half-done; the stable `eptss-sub<id>` rkey makes a retry an upsert.
3. **Caption → `note`** — the four long-form reflection prompts stay in Postgres `additional_comments`; the public record carries only a short caption.

## Scope notes

- **No DB migration. No net dependency change** (`bun.lock` untouched).
- Requires a linked Bluesky account to submit (the ownership guard needs the DID, and the record lands in the user's repo).

## Verification

- Typecheck clean: `@eptss/web`, `@eptss/core`, `@eptss/atproto`. Resolver unit tests 6/6; existing atproto suite 49/49.
- **Not browser-verified**: the form renders for an authed user on a covering-phase round, which needs a linked session + round + a real plyr track — not reproducible in CI here. Please run once on a test account before enabling for a live round.

## Known follow-ups (not blocking)

- Editing an existing submission doesn't pre-fill the URL/caption (we store the resolved record, not the pasted URL).
- No rate-limit on the new action yet (auth + ownership gated, so low surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)